### PR TITLE
Simplefmt

### DIFF
--- a/expfmt/decode.go
+++ b/expfmt/decode.go
@@ -43,7 +43,7 @@ func ResponseFormat(h http.Header) Format {
 
 	mediatype, params, err := mime.ParseMediaType(ct)
 	if err != nil {
-		return FmtUnkown
+		return FmtUnknown
 	}
 
 	const (
@@ -54,16 +54,16 @@ func ResponseFormat(h http.Header) Format {
 	switch mediatype {
 	case ProtoType:
 		if p, ok := params["proto"]; ok && p != ProtoProtocol {
-			return FmtUnkown
+			return FmtUnknown
 		}
 		if e, ok := params["encoding"]; ok && e != "delimited" {
-			return FmtUnkown
+			return FmtUnknown
 		}
 		return FmtProtoDelim
 
 	case textType:
 		if v, ok := params["version"]; ok && v != TextVersion {
-			return FmtUnkown
+			return FmtUnknown
 		}
 		return FmtText
 
@@ -78,13 +78,13 @@ func ResponseFormat(h http.Header) Format {
 
 		switch prometheusAPIVersion {
 		case "0.0.2", "":
-			return FmtJSON2
+			return fmtJSON2
 		default:
-			return FmtUnkown
+			return FmtUnknown
 		}
 	}
 
-	return FmtUnkown
+	return FmtUnknown
 }
 
 // NewDecoder returns a new decoder based on the given input format.
@@ -92,11 +92,11 @@ func ResponseFormat(h http.Header) Format {
 func NewDecoder(r io.Reader, format Format) Decoder {
 	switch format {
 	case FmtProtoDelim:
-		return &protoDecoder{r: r}, nil
-	case FmtJSON2:
-		return newJSON2Decoder(r), nil
+		return &protoDecoder{r: r}
+	case fmtJSON2:
+		return newJSON2Decoder(r)
 	}
-	return &textDecoder{r: r}, nil
+	return &textDecoder{r: r}
 }
 
 // protoDecoder implements the Decoder interface for protocol buffers.
@@ -129,13 +129,14 @@ func (d *textDecoder) Decode(v *dto.MetricFamily) error {
 		if len(fams) == 0 {
 			return io.EOF
 		}
+		d.fams = make([]*dto.MetricFamily, 0, len(fams))
 		for _, f := range fams {
 			d.fams = append(d.fams, f)
 		}
 	}
 
-	*v = *d.fams[len(d.fams)-1]
-	d.fams = d.fams[:len(d.fams)-1]
+	*v = *d.fams[0]
+	d.fams = d.fams[1:]
 
 	return nil
 }

--- a/expfmt/decode_test.go
+++ b/expfmt/decode_test.go
@@ -14,7 +14,6 @@
 package expfmt
 
 import (
-	"errors"
 	"io"
 	"net/http"
 	"reflect"
@@ -304,32 +303,26 @@ func testDiscriminatorHTTPHeader(t testing.TB) {
 		{
 			input:  map[string]string{"Content-Type": `application/vnd.google.protobuf; proto="io.prometheus.client.MetricFamily"; encoding="delimited"`},
 			output: FmtProtoDelim,
-			err:    nil,
 		},
 		{
 			input:  map[string]string{"Content-Type": `application/vnd.google.protobuf; proto="illegal"; encoding="delimited"`},
-			output: "",
-			err:    errors.New("unrecognized protocol message illegal"),
+			output: FmtUnknown,
 		},
 		{
 			input:  map[string]string{"Content-Type": `application/vnd.google.protobuf; proto="io.prometheus.client.MetricFamily"; encoding="illegal"`},
-			output: "",
-			err:    errors.New("unsupported encoding illegal"),
+			output: FmtUnknown,
 		},
 		{
 			input:  map[string]string{"Content-Type": `text/plain; version=0.0.4`},
 			output: FmtText,
-			err:    nil,
 		},
 		{
 			input:  map[string]string{"Content-Type": `text/plain`},
 			output: FmtText,
-			err:    nil,
 		},
 		{
 			input:  map[string]string{"Content-Type": `text/plain; version=0.0.3`},
-			output: "",
-			err:    errors.New("unrecognized protocol version 0.0.3"),
+			output: FmtUnknown,
 		},
 	}
 
@@ -344,19 +337,9 @@ func testDiscriminatorHTTPHeader(t testing.TB) {
 			header.Add(key, value)
 		}
 
-		actual, err := ResponseFormat(header)
+		actual := ResponseFormat(header)
 
-		if scenario.err != err {
-			if scenario.err != nil && err != nil {
-				if scenario.err.Error() != err.Error() {
-					t.Errorf("%d. expected %s, got %s", i, scenario.err, err)
-				}
-			} else if scenario.err != nil || err != nil {
-				t.Errorf("%d. expected %s, got %s", i, scenario.err, err)
-			}
-		}
-
-		if !reflect.DeepEqual(scenario.output, actual) {
+		if scenario.output != actual {
 			t.Errorf("%d. expected %s, got %s", i, scenario.output, actual)
 		}
 	}

--- a/expfmt/expfmt.go
+++ b/expfmt/expfmt.go
@@ -24,11 +24,14 @@ const (
 	ProtoFmt      = ProtoType + "; proto=" + ProtoProtocol + ";"
 
 	// The Content-Type values for the different wire protocols.
+	FmtUnkown       Format = `<unknown>`
 	FmtText         Format = `text/plain; version=` + TextVersion
 	FmtProtoDelim   Format = ProtoFmt + ` encoding=delimited`
 	FmtProtoText    Format = ProtoFmt + ` encoding=text`
 	FmtProtoCompact Format = ProtoFmt + ` encoding=compact-text`
-	FmtJSON2        Format = `application/json; version=0.0.2`
+
+	// fmtJSON2 is hidden as it is deprecated.
+	fmtJSON2 Format = `application/json; version=0.0.2`
 )
 
 const (

--- a/expfmt/expfmt.go
+++ b/expfmt/expfmt.go
@@ -24,7 +24,7 @@ const (
 	ProtoFmt      = ProtoType + "; proto=" + ProtoProtocol + ";"
 
 	// The Content-Type values for the different wire protocols.
-	FmtUnkown       Format = `<unknown>`
+	FmtUnknown      Format = `<unknown>`
 	FmtText         Format = `text/plain; version=` + TextVersion
 	FmtProtoDelim   Format = ProtoFmt + ` encoding=delimited`
 	FmtProtoText    Format = ProtoFmt + ` encoding=text`


### PR DESCRIPTION
Neither `ResponseFormat` nor `NewDecoder` return an error now. If one wants to check whether format was valid, one can validate that `ResponseFormat() != FmtUnknown`. Having a `Format` value that is not one of the constants is a programming flaw, so nothing we should catch via an extra error in `NewDecoder`.

@juliusv @beorn7 