### PR TITLE
Add generatorURL to Alert struct

### DIFF
--- a/model/alert.go
+++ b/model/alert.go
@@ -35,8 +35,9 @@ type Alert struct {
 	Annotations LabelSet `json:"annotations"`
 
 	// The known time range for this alert. Both ends are optional.
-	StartsAt time.Time `json:"startsAt,omitempty"`
-	EndsAt   time.Time `json:"endsAt,omitempty"`
+	StartsAt     time.Time `json:"startsAt,omitempty"`
+	EndsAt       time.Time `json:"endsAt,omitempty"`
+	GeneratorURL string    `json:"generatorURL"`
 }
 
 // Name returns the name of the alert. It is equivalent to the "alertname" label.


### PR DESCRIPTION
@brian-brazil 

Wondering how to handle this field though. Should it really always be an URL. I don't think all clients necessarily fulfill that. 