### PR TITLE
Validate protobuf label names on decode.

### DIFF
--- a/expfmt/decode_test.go
+++ b/expfmt/decode_test.go
@@ -294,6 +294,25 @@ func TestProtoDecoder(t *testing.T) {
 	}
 }
 
+func TestProtoDecoderFailsOnBadLabel(t *testing.T) {
+	var testTime = model.Now()
+
+	badLabelScenario := "\x8f\x01\n\rrequest_count\x12\x12Number of requests\x18\x00\"0\n#\n\x0fsome-label_name\x12\x10some_label_value\x1a\t\t\x00\x00\x00\x00\x00\x00E\xc0\"6\n)\n\x12another_label_name\x12\x13another_label_value\x1a\t\t\x00\x00\x00\x00\x00\x00U@"
+
+	dec := &SampleDecoder{
+		Dec: &protoDecoder{r: strings.NewReader(badLabelScenario)},
+		Opts: &DecodeOptions{
+			Timestamp: testTime,
+		},
+	}
+
+	var smpls model.Vector
+	err := dec.Decode(&smpls)
+	if err == nil {
+		t.Fatal("Bad label should decode with error.")
+	}
+}
+
 func testDiscriminatorHTTPHeader(t testing.TB) {
 	var scenarios = []struct {
 		input  map[string]string


### PR DESCRIPTION
Based on prometheus/prometheus/issues/1232, we are not validating protobuf label names on decode.

This patch provides a [test](https://github.com/jpittis/common/blob/5fde791b57d7901fdf17b3f0439769467329949f/expfmt/decode_test.go#L297-L314) to confirm bad labels normally decode without error and adds [validation](https://github.com/jpittis/common/blob/5fde791b57d7901fdf17b3f0439769467329949f/expfmt/decode.go#L112-L120).

For the test, I stole a passing test case and mutated the label name to be incorrect.

I'm unsure if this is the best place to perform validation. I am also unsure that the error being returned from `Decode` is clear enough.

ping: @beorn7 @fabxc 