### PR TITLE
Remove the last occurrence of `utf8.ValidString`

### DIFF
--- a/model/silence.go
+++ b/model/silence.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"regexp"
 	"time"
-	"unicode/utf8"
 )
 
 // Matcher describes a matches the value of a given label.
@@ -54,7 +53,7 @@ func (m *Matcher) Validate() error {
 		if _, err := regexp.Compile(m.Value); err != nil {
 			return fmt.Errorf("invalid regular expression %q", m.Value)
 		}
-	} else if !utf8.ValidString(m.Value) || len(m.Value) == 0 {
+	} else if !LabelValue(m.Value).IsValid() || len(m.Value) == 0 {
 		return fmt.Errorf("invalid value %q", m.Value)
 	}
 	return nil


### PR DESCRIPTION
It's all redirected to model.LabelValue.IsValid now.  We use string as
type for Matcher.Value because it could be a regexp rather than a
LabelValue.

@fabxc 