### PR TITLE
Limit syslogger to unix systems

### DIFF
--- a/log/syslog_formatter.go
+++ b/log/syslog_formatter.go
@@ -1,3 +1,18 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !windows,!nacl,!plan9
+
 package log
 
 import (
@@ -7,6 +22,26 @@ import (
 
 	"github.com/Sirupsen/logrus"
 )
+
+func init() {
+	setSyslogFormatter = func(appname, local string) error {
+		if appname == "" {
+			return fmt.Errorf("missing appname parameter")
+		}
+		if local == "" {
+			return fmt.Errorf("missing local parameter")
+		}
+
+		fmter, err := newSyslogger(appname, local, origLogger.Formatter)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error creating syslog formatter: %v\n", err)
+			origLogger.Errorf("can't connect logger to syslog: %v", err)
+			return err
+		}
+		origLogger.Formatter = fmter
+		return nil
+	}
+}
 
 var ceeTag = []byte("@cee:")
 


### PR DESCRIPTION
Currently packages importing `common/log` will not compile on Windows and other systems due to the missing build constraints for the syslog formatter.

@brian-brazil 