### PR TITLE
Extend Duration to years and weeks

### DIFF
--- a/model/time.go
+++ b/model/time.go
@@ -163,10 +163,10 @@ func (t *Time) UnmarshalJSON(b []byte) error {
 // This type should not propagate beyond the scope of input/output processing.
 type Duration time.Duration
 
-var durationRE = regexp.MustCompile("^([0-9]+)(d|h|m|s|ms)$")
+var durationRE = regexp.MustCompile("^([0-9]+)(y|w|d|h|m|s|ms)$")
 
 // StringToDuration parses a string into a time.Duration, assuming that a year
-// a day always has 24h.
+// always has 365d, a week always has 7d, and a day always has 24h.
 func ParseDuration(durationStr string) (Duration, error) {
 	matches := durationRE.FindStringSubmatch(durationStr)
 	if len(matches) != 3 {
@@ -177,6 +177,10 @@ func ParseDuration(durationStr string) (Duration, error) {
 		dur  = time.Duration(n) * time.Millisecond
 	)
 	switch unit := matches[2]; unit {
+	case "y":
+		dur *= 1000 * 60 * 60 * 24 * 365
+	case "w":
+		dur *= 1000 * 60 * 60 * 24 * 7
 	case "d":
 		dur *= 1000 * 60 * 60 * 24
 	case "h":
@@ -199,6 +203,8 @@ func (d Duration) String() string {
 		unit = "ms"
 	)
 	factors := map[string]int64{
+		"y":  1000 * 60 * 60 * 24 * 365,
+		"w":  1000 * 60 * 60 * 24 * 7,
 		"d":  1000 * 60 * 60 * 24,
 		"h":  1000 * 60 * 60,
 		"m":  1000 * 60,
@@ -207,6 +213,10 @@ func (d Duration) String() string {
 	}
 
 	switch int64(0) {
+	case ms % factors["y"]:
+		unit = "y"
+	case ms % factors["w"]:
+		unit = "w"
 	case ms % factors["d"]:
 		unit = "d"
 	case ms % factors["h"]:

--- a/model/time_test.go
+++ b/model/time_test.go
@@ -105,6 +105,12 @@ func TestParseDuration(t *testing.T) {
 		}, {
 			in:  "4d",
 			out: 4 * 24 * time.Hour,
+		}, {
+			in:  "3w",
+			out: 3 * 7 * 24 * time.Hour,
+		}, {
+			in:  "10y",
+			out: 10 * 365 * 24 * time.Hour,
 		},
 	}
 


### PR DESCRIPTION
I'm currently working on unifying all Duration parsing. While it's
arguably rarely useful to use y or w, I'm pretty sure that we have
users doing it (and we have separate parsing code still in place
supporting it (and I'm working on removing that other parsing code)).

I'd hate to break people's expressions and configs just because we
think 1w is too long for a range...

@fabxc 