### PR TITLE
Return meaningful error instead of EOF during text parsing

### DIFF
--- a/expfmt/text_parse.go
+++ b/expfmt/text_parse.go
@@ -108,6 +108,13 @@ func (p *TextParser) TextToMetricFamilies(in io.Reader) (map[string]*dto.MetricF
 			delete(p.metricFamiliesByName, k)
 		}
 	}
+	// If p.err is io.EOF now, we have run into a premature end of the input
+	// stream. Turn this error into something nicer and more
+	// meaningful. (io.EOF is often used as a signal for the legitimate end
+	// of an input stream.)
+	if p.err == io.EOF {
+		p.parseError("unexpected end of input stream")
+	}
 	return p.metricFamiliesByName, p.err
 }
 

--- a/expfmt/text_parse_test.go
+++ b/expfmt/text_parse_test.go
@@ -434,8 +434,10 @@ func testTextParseError(t testing.TB) {
 	}{
 		// 0: No new-line at end of input.
 		{
-			in:  `bla 3.14`,
-			err: "EOF",
+			in: `
+bla 3.14
+blubber 42`,
+			err: "text format parsing error in line 3: unexpected end of input stream",
 		},
 		// 1: Invalid escape sequence in label value.
 		{


### PR DESCRIPTION
So far, we are just passing through the io.EOF error created when
trying to read from the input stream. That io.EOF error doesn't tell
the caller the position where it has happened, and worse, it could
easily misunderstood as a signal for the legitimate end of the input
stream.

@fabxc FIxes https://github.com/prometheus/prometheus/issues/1135