### PR TITLE
Empty vector is the same as a non-empty vector without that label.

### DIFF
--- a/model/signature.go
+++ b/model/signature.go
@@ -98,7 +98,7 @@ func labelSetToFastFingerprint(ls LabelSet) Fingerprint {
 // specified LabelNames into the signature calculation. The labels passed in
 // will be sorted by this function.
 func SignatureForLabels(m Metric, labels ...LabelName) uint64 {
-	if len(m) == 0 || len(labels) == 0 {
+	if len(labels) == 0 {
 		return emptyLabelSignature
 	}
 

--- a/model/signature_test.go
+++ b/model/signature_test.go
@@ -103,6 +103,16 @@ func TestSignatureForLabels(t *testing.T) {
 			out:    14695981039346656037,
 		},
 		{
+			in:     Metric{},
+			labels: LabelNames{"empty"},
+			out:    7187873163539638612,
+		},
+		{
+			in:     Metric{"name": "garland, briggs", "fear": "love is not enough"},
+			labels: LabelNames{"empty"},
+			out:    7187873163539638612,
+		},
+		{
 			in:     Metric{"name": "garland, briggs", "fear": "love is not enough"},
 			labels: LabelNames{"fear", "name"},
 			out:    5799056148416392346,


### PR DESCRIPTION
This is the cause of https://github.com/prometheus/prometheus/issues/1489