### PR TITLE
Remove Go 1.4 from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 
 language: go
 go:
-  - 1.4.3
   - 1.5.4
   - 1.6.2
   - tip


### PR DESCRIPTION
It is incompatible with the current version of the context package.

@clavoie-acquisio @grobie @fabxc 