### PR TITLE
Use strings.Replacer instead of hand-rolled escapeString

### DIFF
--- a/expfmt/text_create.go
+++ b/expfmt/text_create.go
@@ -14,7 +14,6 @@
 package expfmt
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"math"
@@ -285,21 +284,17 @@ func labelPairsToText(
 	return written, nil
 }
 
+var (
+	escape                = strings.NewReplacer("\\", `\\`, "\n", `\n`)
+	escapeWithDoubleQuote = strings.NewReplacer("\\", `\\`, "\n", `\n`, "\"", `\"`)
+)
+
 // escapeString replaces '\' by '\\', new line character by '\n', and - if
 // includeDoubleQuote is true - '"' by '\"'.
 func escapeString(v string, includeDoubleQuote bool) string {
-	result := bytes.NewBuffer(make([]byte, 0, len(v)))
-	for _, c := range v {
-		switch {
-		case c == '\\':
-			result.WriteString(`\\`)
-		case includeDoubleQuote && c == '"':
-			result.WriteString(`\"`)
-		case c == '\n':
-			result.WriteString(`\n`)
-		default:
-			result.WriteRune(c)
-		}
+	if includeDoubleQuote {
+		return escapeWithDoubleQuote.Replace(v)
 	}
-	return result.String()
+
+	return escape.Replace(v)
 }


### PR DESCRIPTION
This reduces run-time (since replacement is done via table lookup) and memory consumption (since strings that do not need replacing are returned as they are).

    name      old time/op    new time/op    delta
    Create-4    66.9µs ± 3%    55.0µs ±12%  -17.82%  (p=0.008 n=5+5)

    name      old alloc/op   new alloc/op   delta
    Create-4    19.2kB ± 0%    13.7kB ± 0%  -28.44%  (p=0.008 n=5+5)

    name      old allocs/op  new allocs/op  delta
    Create-4       617 ± 0%       498 ± 0%  -19.29%  (p=0.008 n=5+5)