### PR TITLE
Documentation fixes

### DIFF
--- a/expfmt/text_create.go
+++ b/expfmt/text_create.go
@@ -25,9 +25,12 @@ import (
 
 // MetricFamilyToText converts a MetricFamily proto message into text format and
 // writes the resulting lines to 'out'. It returns the number of bytes written
-// and any error encountered.  This function does not perform checks on the
-// content of the metric and label names, i.e. invalid metric or label names
+// and any error encountered. The output will have the same order as the input,
+// no further sorting is performed. Furthermore, this function assumes the input
+// is already sanitized and does not perform any sanity checks. If the input
+// contains duplicate metrics or invalid metric or label names, the conversion
 // will result in invalid text format output.
+//
 // This method fulfills the type 'prometheus.encoder'.
 func MetricFamilyToText(out io.Writer, in *dto.MetricFamily) (int, error) {
 	var written int

--- a/expfmt/text_parse.go
+++ b/expfmt/text_parse.go
@@ -47,7 +47,7 @@ func (e ParseError) Error() string {
 }
 
 // TextParser is used to parse the simple and flat text-based exchange format. Its
-// nil value is ready to use.
+// zero value is ready to use.
 type TextParser struct {
 	metricFamiliesByName map[string]*dto.MetricFamily
 	buf                  *bufio.Reader // Where the parsed input is read through.


### PR DESCRIPTION
This acknowledges the fact that duplicate metrics in the slice passed
to MetricFamilyToText will result in invalid text format.

This is meant to document the status quo and bears no implication for
the possible loosening of the text format spec, cf. #54.

@brian-brazil @fabxc 