### PR TITLE
Adjust the MetricNameRE to reflect the actual behavior

### DIFF
--- a/model/metric.go
+++ b/model/metric.go
@@ -22,7 +22,7 @@ import (
 
 var (
 	separator    = []byte{0}
-	MetricNameRE = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_:]*$`)
+	MetricNameRE = regexp.MustCompile(`^[a-zA-Z_:][a-zA-Z0-9_:]*$`)
 )
 
 // A Metric is similar to a LabelSet, but the key difference is that a Metric is


### PR DESCRIPTION
Note that the validation in
https://github.com/prometheus/common/blob/master/model/metric.go#L93
does not actually use MetricNameRE. Right now, the regexp is more
documentation than anything else, although some might use it (which is
one of the reasons to keep it around).

In any case, the regexp should match exactly the same strings that are
matched by the IsValidMetricName function in
https://github.com/prometheus/common/blob/master/model/metric.go#L93
matches.

@brian-brazil 