### PR TITLE
Remove last remaining use of LabelNameRE

### DIFF
--- a/model/labels.go
+++ b/model/labels.go
@@ -80,14 +80,18 @@ const (
 	QuantileLabel = "quantile"
 )
 
-// LabelNameRE is a regular expression matching valid label names.
+// LabelNameRE is a regular expression matching valid label names. Note that the
+// IsValid method of LabelName performs the same check but faster than a metch
+// with this regular expression.
 var LabelNameRE = regexp.MustCompile("^[a-zA-Z_][a-zA-Z0-9_]*$")
 
 // A LabelName is a key for a LabelSet or Metric.  It has a value associated
 // therewith.
 type LabelName string
 
-// IsValid is true iff the label name matches the pattern of LabelNameRE.
+// IsValid is true iff the label name matches the pattern of LabelNameRE. ;This
+// method, however, does not use LabelNameRE for the check but a much faster
+// hardcoded implementation.
 func (ln LabelName) IsValid() bool {
 	if len(ln) == 0 {
 		return false
@@ -106,7 +110,7 @@ func (ln *LabelName) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	if err := unmarshal(&s); err != nil {
 		return err
 	}
-	if !LabelNameRE.MatchString(s) {
+	if !LabelName(s).IsValid() {
 		return fmt.Errorf("%q is not a valid label name", s)
 	}
 	*ln = LabelName(s)
@@ -119,7 +123,7 @@ func (ln *LabelName) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &s); err != nil {
 		return err
 	}
-	if !LabelNameRE.MatchString(s) {
+	if !LabelName(s).IsValid() {
 		return fmt.Errorf("%q is not a valid label name", s)
 	}
 	*ln = LabelName(s)

--- a/model/labels.go
+++ b/model/labels.go
@@ -81,7 +81,7 @@ const (
 )
 
 // LabelNameRE is a regular expression matching valid label names. Note that the
-// IsValid method of LabelName performs the same check but faster than a metch
+// IsValid method of LabelName performs the same check but faster than a match
 // with this regular expression.
 var LabelNameRE = regexp.MustCompile("^[a-zA-Z_][a-zA-Z0-9_]*$")
 
@@ -89,7 +89,7 @@ var LabelNameRE = regexp.MustCompile("^[a-zA-Z_][a-zA-Z0-9_]*$")
 // therewith.
 type LabelName string
 
-// IsValid is true iff the label name matches the pattern of LabelNameRE. ;This
+// IsValid is true iff the label name matches the pattern of LabelNameRE. This
 // method, however, does not use LabelNameRE for the check but a much faster
 // hardcoded implementation.
 func (ln LabelName) IsValid() bool {

--- a/model/labels_test.go
+++ b/model/labels_test.go
@@ -119,6 +119,14 @@ func TestLabelNameIsValid(t *testing.T) {
 			ln:    "a lid_23name",
 			valid: false,
 		},
+		{
+			ln:    ":leading_colon",
+			valid: false,
+		},
+		{
+			ln:    "colon:in:the:middle",
+			valid: false,
+		},
 	}
 
 	for _, s := range scenarios {

--- a/model/labels_test.go
+++ b/model/labels_test.go
@@ -131,7 +131,10 @@ func TestLabelNameIsValid(t *testing.T) {
 
 	for _, s := range scenarios {
 		if s.ln.IsValid() != s.valid {
-			t.Errorf("Expected %v for %q", s.valid, s.ln)
+			t.Errorf("Expected %v for %q using IsValid method", s.valid, s.ln)
+		}
+		if LabelNameRE.MatchString(string(s.ln)) != s.valid {
+			t.Errorf("Expected %v for %q using regexp match", s.valid, s.ln)
 		}
 	}
 }

--- a/model/labelset.go
+++ b/model/labelset.go
@@ -160,7 +160,7 @@ func (l *LabelSet) UnmarshalJSON(b []byte) error {
 	// LabelName as a string and does not call its UnmarshalJSON method.
 	// Thus, we have to replicate the behavior here.
 	for ln := range m {
-		if !LabelNameRE.MatchString(string(ln)) {
+		if !ln.IsValid() {
 			return fmt.Errorf("%q is not a valid label name", ln)
 		}
 	}

--- a/model/metric.go
+++ b/model/metric.go
@@ -24,7 +24,7 @@ var (
 	separator = []byte{0}
 	// MetricNameRE is a regular expression matching valid metric
 	// names. Note that the IsValidMetricName function performs the same
-	// check but faster than a metch with this regular expression.
+	// check but faster than a match with this regular expression.
 	MetricNameRE = regexp.MustCompile(`^[a-zA-Z_:][a-zA-Z0-9_:]*$`)
 )
 

--- a/model/metric.go
+++ b/model/metric.go
@@ -21,7 +21,10 @@ import (
 )
 
 var (
-	separator    = []byte{0}
+	separator = []byte{0}
+	// MetricNameRE is a regular expression matching valid metric
+	// names. Note that the IsValidMetricName function performs the same
+	// check but faster than a metch with this regular expression.
 	MetricNameRE = regexp.MustCompile(`^[a-zA-Z_:][a-zA-Z0-9_:]*$`)
 )
 
@@ -85,6 +88,8 @@ func (m Metric) FastFingerprint() Fingerprint {
 }
 
 // IsValidMetricName returns true iff name matches the pattern of MetricNameRE.
+// This function, however, does not use MetricNameRE for the check but a much
+// faster hardcoded implementation.
 func IsValidMetricName(n LabelValue) bool {
 	if len(n) == 0 {
 		return false

--- a/model/metric_test.go
+++ b/model/metric_test.go
@@ -111,6 +111,14 @@ func TestMetricNameIsValid(t *testing.T) {
 			mn:    "a lid_23name",
 			valid: false,
 		},
+		{
+			mn:    ":leading_colon",
+			valid: true,
+		},
+		{
+			mn:    "colon:in:the:middle",
+			valid: true,
+		},
 	}
 
 	for _, s := range scenarios {

--- a/model/metric_test.go
+++ b/model/metric_test.go
@@ -123,7 +123,10 @@ func TestMetricNameIsValid(t *testing.T) {
 
 	for _, s := range scenarios {
 		if IsValidMetricName(s.mn) != s.valid {
-			t.Errorf("Expected %v for %q", s.valid, s.mn)
+			t.Errorf("Expected %v for %q using IsValidMetricName function", s.valid, s.mn)
+		}
+		if MetricNameRE.MatchString(string(s.mn)) != s.valid {
+			t.Errorf("Expected %v for %q using regexp matching", s.valid, s.mn)
 		}
 	}
 }


### PR DESCRIPTION
The IsValid method is much faster.

Same as MetricNameRE, the regexp is mostly there for documentation
reasons.

This commit also clarifies that in the doc comments and encourages
using the IsValid method (or IsValidMatricName function) for
performance reasons.

@grobie @stuartnelson3 