### PR TITLE
Fix logrus import

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ components and libraries.
 
 * **config**: Common configuration structures
 * **expfmt**: Decoding and encoding for the exposition format
-* **log**: A logging wrapper around [logrus](https://github.com/Sirupsen/logrus)
+* **log**: A logging wrapper around [logrus](https://github.com/sirupsen/logrus)
 * **model**: Shared data structures
 * **route**: A routing wrapper around [httprouter](https://github.com/julienschmidt/httprouter) using `context.Context`
 * **version**: Version informations and metric

--- a/log/eventlog_formatter.go
+++ b/log/eventlog_formatter.go
@@ -21,7 +21,7 @@ import (
 
 	"golang.org/x/sys/windows/svc/eventlog"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 func init() {

--- a/log/log.go
+++ b/log/log.go
@@ -25,7 +25,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 type levelFlag string

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -18,7 +18,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 func TestFileLineLogging(t *testing.T) {

--- a/log/syslog_formatter.go
+++ b/log/syslog_formatter.go
@@ -20,7 +20,7 @@ import (
 	"log/syslog"
 	"os"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 var _ logrus.Formatter = (*syslogger)(nil)


### PR DESCRIPTION
The author of logrus has changed his GitHub username from Sirupsen to
sirupsen. The case change breaks logrus imports for packages whose
dependencies import logrus using the other casing.

See also, sirupsen/logrus#384