### PR TITLE
Fall back on environment http proxies

### DIFF
--- a/config/http_config.go
+++ b/config/http_config.go
@@ -121,9 +121,16 @@ func NewHTTPClientFromConfig(cfg *HTTPClientConfig) (*http.Client, error) {
 		return nil, err
 	}
 
+	var proxyFunc func(*http.Request) (*url.URL, error)
+	if cfg.ProxyURL.URL != nil {
+		proxyFunc = http.ProxyURL(cfg.ProxyURL.URL)
+	} else {
+		proxyFunc = http.ProxyFromEnvironment
+	}
+
 	// It's the caller's job to handle timeouts
 	var rt http.RoundTripper = &http.Transport{
-		Proxy:             http.ProxyURL(cfg.ProxyURL.URL),
+		Proxy:             proxyFunc,
 		DisableKeepAlives: true,
 		TLSClientConfig:   tlsConfig,
 	}


### PR DESCRIPTION
If no explicit proxy URL is defined, try to use the proxies (HTTP_PROXY, HTTPS_PROXY, NO_PROXY) defined in the process' environment.

Pull request as followup of https://github.com/prometheus/blackbox_exporter/issues/190