### PR TITLE
Switch to kingpin in log

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -24,9 +24,8 @@ import (
 	"strconv"
 	"strings"
 
-	"gopkg.in/alecthomas/kingpin.v2"
-
 	"github.com/sirupsen/logrus"
+	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 // setSyslogFormatter is nil if the target architecture does not support syslog.

--- a/log/log.go
+++ b/log/log.go
@@ -53,6 +53,8 @@ func (s *loggerSettings) apply(ctx *kingpin.ParseContext) error {
 	return err
 }
 
+// AddFlags adds the flags used by this package to the Kingpin application.
+// To use the default Kingpin application, call AddFlags(kingpin.CommandLine)
 func AddFlags(a *kingpin.Application) {
 	s := loggerSettings{}
 	kingpin.Flag("log.level", "Only log messages with the given severity or above. Valid levels: [debug, info, warn, error, fatal]").

--- a/log/log.go
+++ b/log/log.go
@@ -53,14 +53,6 @@ func (s *loggerSettings) apply(ctx *kingpin.ParseContext) error {
 	return err
 }
 
-func init() {
-	AddFlags(kingpin.CommandLine)
-}
-
-// AddFlags adds the flags used by this package to the Kingpin application. That's
-// useful if working with a custom application. The init function of this package
-// adds the flags to the default instance anyway. Thus, it's usually enough to call
-// kingpin.Parse() to make the logging flags take effect.
 func AddFlags(a *kingpin.Application) {
 	s := loggerSettings{}
 	kingpin.Flag("log.level", "Only log messages with the given severity or above. Valid levels: [debug, info, warn, error, fatal]").

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -32,7 +32,7 @@ func TestFileLineLogging(t *testing.T) {
 	Debug("This debug-level line should not show up in the output.")
 	Infof("This %s-level line should show up in the output.", "info")
 
-	re := `^time=".*" level=info msg="This info-level line should show up in the output." source="log_test.go:33" \n$`
+	re := `^time=".*" level=info msg="This info-level line should show up in the output." source="log_test.go:33"\n$`
 	if !regexp.MustCompile(re).Match(buf.Bytes()) {
 		t.Fatalf("%q did not match expected regex %q", buf.String(), re)
 	}


### PR DESCRIPTION
This switches the flag package to kingpin as discussed in [Prometheus#2455](https://github.com/prometheus/prometheus/issues/2455) and [influxdb_exporter#15](https://github.com/prometheus/influxdb_exporter/pull/15).

I've also tested building and running Prometheus with the dev-2.0 branch to ensure these changes does not impact how logging flags are initialized there, and it seems to work as expected.

People not vendoring this package will get a surprise though if this is merged. Is this something that needs to be considered?