### PR TITLE
Add ability to register hooks to underlying logger

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -345,6 +345,11 @@ func Fatalf(format string, args ...interface{}) {
 	baseLogger.sourced().Fatalf(format, args...)
 }
 
+// AddHook adds hook to Prometheus' original logger.
+func AddHook(hook logrus.Hook) {
+	origLogger.Hooks.Add(hook)
+}
+
 type errorLogWriter struct{}
 
 func (errorLogWriter) Write(b []byte) (int, error) {


### PR DESCRIPTION
This propagates upstream a change made in weaveworks/cortex/pull/572 to allow to register `logrus` hooks to the underlying (default) logger used by Prometheus.

This change is admittedly very crude, leaks the fact `logrus` is used under the cover, but this works for what was needed in Cortex.

I'm happy to come up with a more generic & robust implementation, nicer abstraction, etc. so please just let me know what the expectations are if you find this PR inappropriate.

CC: @fabxc (since you're listed in `MAINTAINERS.md`, thanks! :slightly_smiling_face:).