### PR TITLE
Include go1.8 and go1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,6 @@ sudo: false
 language: go
 go:
   - 1.7.5
+  - 1.8.3
+  - 1.9.x
   - tip


### PR DESCRIPTION
This change adds the last 2 versions of go into the build matrix.