### PR TITLE
Feature: Add check_license.sh

### DIFF
--- a/scripts/check_license.sh
+++ b/scripts/check_license.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+licRes=$(
+for file in $(find . -type f -iname '*.go' ! -path './internal/*'); do
+	head -n3 "${file}" | grep -Eq "(Copyright|generated|GENERATED)" || echo -e "  ${file}"
+done;)
+if [ -n "${licRes}" ]; then
+	echo -e "license header checking failed:\n${licRes}"
+	exit 255
+fi


### PR DESCRIPTION
There is currently no automated script to ensure all source files have
a license header, fortunately Prometheus already has a script provided by @jonboulle and I have simply
copied that script and applied it to this code base.

Example output:
```
github.com/prometheus/common on  feat-add-license-check [+]
➜ ./scripts/check_license.sh
-e license header checking failed:
-e   ./route/route.go
-e   ./route/route_test.go
```

All credit to @jonboulle for the initial script.