### PR TITLE
Use seconds instead of years for zero durations

### DIFF
--- a/model/time.go
+++ b/model/time.go
@@ -214,6 +214,9 @@ func (d Duration) String() string {
 		ms   = int64(time.Duration(d) / time.Millisecond)
 		unit = "ms"
 	)
+	if ms == 0 {
+		return "0s"
+	}
 	factors := map[string]int64{
 		"y":  1000 * 60 * 60 * 24 * 365,
 		"w":  1000 * 60 * 60 * 24 * 7,

--- a/model/time_test.go
+++ b/model/time_test.go
@@ -91,6 +91,9 @@ func TestParseDuration(t *testing.T) {
 		out time.Duration
 	}{
 		{
+			in:  "0s",
+			out: 0,
+		}, {
 			in:  "324ms",
 			out: 324 * time.Millisecond,
 		}, {


### PR DESCRIPTION
`0y` looks very, very weird.