### PR TITLE
Add charset to text/plain Content-Type

### DIFF
--- a/expfmt/expfmt.go
+++ b/expfmt/expfmt.go
@@ -26,7 +26,7 @@ const (
 
 	// The Content-Type values for the different wire protocols.
 	FmtUnknown      Format = `<unknown>`
-	FmtText         Format = `text/plain; charset=utf-8; version=` + TextVersion
+	FmtText         Format = `text/plain; version=` + TextVersion + `; charset=utf-8`
 	FmtProtoDelim   Format = ProtoFmt + ` encoding=delimited`
 	FmtProtoText    Format = ProtoFmt + ` encoding=text`
 	FmtProtoCompact Format = ProtoFmt + ` encoding=compact-text`

--- a/expfmt/expfmt.go
+++ b/expfmt/expfmt.go
@@ -26,7 +26,7 @@ const (
 
 	// The Content-Type values for the different wire protocols.
 	FmtUnknown      Format = `<unknown>`
-	FmtText         Format = `text/plain; version=` + TextVersion
+	FmtText         Format = `text/plain; charset=utf-8; version=` + TextVersion
 	FmtProtoDelim   Format = ProtoFmt + ` encoding=delimited`
 	FmtProtoText    Format = ProtoFmt + ` encoding=text`
 	FmtProtoCompact Format = ProtoFmt + ` encoding=compact-text`


### PR DESCRIPTION
This fixes encoding issues when viewing `/metrics` directly.

See also https://github.com/prometheus/docs/issues/557, https://github.com/prometheus/prometheus/issues/1988