### PR TITLE
add a common makefile

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -18,12 +18,11 @@
 # Create the main Makefile in the root project directory. 
 # Add a "catch all" rule which will run when no other local rule is an exact match.
 # %:
-# 	@echo ">> downloading common Makefile"
-# 	#Try to download a fresh copy, but continue even if it fails.
+# 	@echo ">> downloading a fresh copy of the Makefile.common"
+# 	# It will use the cached version in case the pull fails.
 # 	# -f do NOT overwrite the file in case of a network error. Keep cached copy!
-# 	#This allows running the cached version or Makefile.common when working offline.
-# 	curl https://raw.githubusercontent.com/prometheus/common/master/Makefile.common -f -o Makefile.common || true  
-# 	make -f Makefile.common $@
+# 	@curl https://raw.githubusercontent.com/prometheus/common/master/Makefile.common -f -o Makefile.common || true  
+# 	@make -f Makefile.common $@
 # local-rule:
 # 	@echo ">> runing a local rules which has a priority over the catch all rule"
 
@@ -69,6 +68,8 @@ style:
 
 check_license:
 	@echo ">> checking license header"
+	@mkdir scripts
+	@curl https://raw.githubusercontent.com/prometheus/common/master/scripts/check_license.sh -f -o scripts/check_license.sh || true  
 	@./scripts/check_license.sh
 
 # TODO(fabxc): example tests temporarily removed.

--- a/Makefile.common
+++ b/Makefile.common
@@ -14,6 +14,8 @@
 
 # A common Makefile that includes rules to be reused in different prometheus projects.
 
+# !!! Open PRs only against the prometheus/common repository!
+
 # Example usage :
 # Create the main Makefile in the root project directory. 
 # Add a "catch all" rule which will run when no other local rule is an exact match.

--- a/Makefile.common
+++ b/Makefile.common
@@ -1,0 +1,127 @@
+# Copyright 2018 The Prometheus Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# A common Makefile that includes rules to be reused in different prometheus projects.
+
+# Example usage :
+# Create the main Makefile in the root project directory. 
+# Add a "catch all" rule which will run when no other local rule is an exact match.
+# %:
+# 	@echo ">> downloading common Makefile"
+# 	#Try to download a fresh copy, but continue even if it fails.
+# 	# -f do NOT overwrite the file in case of a network error. Keep cached copy!
+# 	#This allows running the cached version or Makefile.common when working offline.
+# 	curl https://raw.githubusercontent.com/prometheus/common/master/Makefile.common -f -o Makefile.common || true  
+# 	make -f Makefile.common $@
+# local-rule:
+# 	@echo ">> runing a local rules which has a priority over the catch all rule"
+
+# Any env to be passed down the Makefile.common should be put before the "catch all" rule in the format
+# export DOCKER_IMAGE_NAME       ?= prometheus
+
+
+
+# Ensure GOBIN is not set during build so that promu is installed to the correct path
+unexport GOBIN
+
+GO           ?= go
+GOFMT        ?= $(GO)fmt
+FIRST_GOPATH := $(firstword $(subst :, ,$(shell $(GO) env GOPATH)))
+PROMU        := $(FIRST_GOPATH)/bin/promu
+STATICCHECK  := $(FIRST_GOPATH)/bin/staticcheck
+GOVENDOR     := $(FIRST_GOPATH)/bin/govendor
+pkgs          = $(shell $(GO) list ./... | grep -v /vendor/)
+
+PREFIX                  ?= $(shell pwd)
+BIN_DIR                 ?= $(shell pwd)
+DOCKER_IMAGE_TAG        ?= $(subst /,-,$(shell git rev-parse --abbrev-ref HEAD))
+DOCKER_IMAGE_NAME       ?= prometheus
+
+ifdef DEBUG
+	bindata_flags = -debug
+endif
+
+STATICCHECK_IGNORE = \
+  github.com/prometheus/prometheus/discovery/kubernetes/kubernetes.go:SA1019 \
+  github.com/prometheus/prometheus/discovery/kubernetes/node.go:SA1019 \
+  github.com/prometheus/prometheus/documentation/examples/remote_storage/remote_storage_adapter/main.go:SA1019 \
+  github.com/prometheus/prometheus/pkg/textparse/lex.l.go:SA4006 \
+  github.com/prometheus/prometheus/pkg/pool/pool.go:SA6002 \
+  github.com/prometheus/prometheus/promql/engine.go:SA6002 \
+  github.com/prometheus/prometheus/web/web.go:SA1019
+
+all: format staticcheck unused build test
+
+style:
+	@echo ">> checking code style"
+	@! $(GOFMT) -d $(shell find . -path ./vendor -prune -o -name '*.go' -print) | grep '^'
+
+check_license:
+	@echo ">> checking license header"
+	@./scripts/check_license.sh
+
+# TODO(fabxc): example tests temporarily removed.
+test-short:
+	@echo ">> running short tests"
+	@$(GO) test -short $(shell $(GO) list ./... | grep -v /vendor/ | grep -v examples)
+
+test:
+	@echo ">> running all tests"
+	@$(GO) test -race $(shell $(GO) list ./... | grep -v /vendor/ | grep -v examples)
+
+format:
+	@echo ">> formatting code"
+	@$(GO) fmt $(pkgs)
+
+vet:
+	@echo ">> vetting code"
+	@$(GO) vet $(pkgs)
+
+staticcheck: $(STATICCHECK)
+	@echo ">> running staticcheck"
+	@$(STATICCHECK) -ignore "$(STATICCHECK_IGNORE)" $(pkgs)
+
+unused: $(GOVENDOR)
+	@echo ">> running check for unused packages"
+	@$(GOVENDOR) list +unused
+
+build: promu
+	@echo ">> building binaries"
+	@$(PROMU) build --prefix $(PREFIX)
+
+tarball: promu
+	@echo ">> building release tarball"
+	@$(PROMU) tarball --prefix $(PREFIX) $(BIN_DIR)
+
+docker:
+	@echo ">> building docker image"
+	@docker build -t "$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)" .
+
+assets:
+	@echo ">> writing assets"
+	@$(GO) get -u github.com/jteeuwen/go-bindata/...
+	@go-bindata $(bindata_flags) -pkg ui -o web/ui/bindata.go -ignore '(.*\.map|bootstrap\.js|bootstrap-theme\.css|bootstrap\.css)'  web/ui/templates/... web/ui/static/...
+	@$(GO) fmt ./web/ui
+
+promu:
+	@echo ">> fetching promu"
+	@GOOS= GOARCH= $(GO) get -u github.com/prometheus/promu
+
+$(FIRST_GOPATH)/bin/staticcheck:
+	@GOOS= GOARCH= $(GO) get -u honnef.co/go/tools/cmd/staticcheck
+
+$(FIRST_GOPATH)/bin/govendor:
+	@GOOS= GOARCH= $(GO) get -u github.com/kardianos/govendor
+
+.PHONY: all style check_license format build test vet assets tarball docker promu staticcheck $(FIRST_GOPATH)/bin/staticcheck govendor $(FIRST_GOPATH)/bin/govendor

--- a/Makefile.common
+++ b/Makefile.common
@@ -20,8 +20,8 @@
 # %:
 # 	@echo ">> downloading a fresh copy of the Makefile.common"
 # 	# It will use the cached version in case the pull fails.
-# 	# -f do NOT overwrite the file in case of a network error. Keep cached copy!
-# 	@curl https://raw.githubusercontent.com/prometheus/common/master/Makefile.common -f -o Makefile.common || true  
+# 	@# -f do NOT overwrite the file in case of a network error. Keep cached copy!
+# 	@curl https://raw.githubusercontent.com/prometheus/common/master/Makefile.common -s -f -o Makefile.common || true  
 # 	@make -f Makefile.common $@
 # local-rule:
 # 	@echo ">> runing a local rules which has a priority over the catch all rule"
@@ -69,7 +69,7 @@ style:
 check_license:
 	@echo ">> checking license header"
 	@mkdir -p scripts
-	@curl https://raw.githubusercontent.com/prometheus/common/master/scripts/check_license.sh -f -o scripts/check_license.sh || true  
+	@curl https://raw.githubusercontent.com/prometheus/common/master/scripts/check_license.sh -s -f -o scripts/check_license.sh || true
 	@./scripts/check_license.sh
 
 # TODO(fabxc): example tests temporarily removed.

--- a/Makefile.common
+++ b/Makefile.common
@@ -68,7 +68,7 @@ style:
 
 check_license:
 	@echo ">> checking license header"
-	@mkdir scripts
+	@mkdir -p scripts
 	@curl https://raw.githubusercontent.com/prometheus/common/master/scripts/check_license.sh -f -o scripts/check_license.sh || true  
 	@./scripts/check_license.sh
 

--- a/Makefile.common
+++ b/Makefile.common
@@ -18,19 +18,18 @@
 
 # Example usage :
 # Create the main Makefile in the root project directory. 
-# Add a "catch all" rule which will run when no other local rule is an exact match.
-# %:
-# 	@echo ">> downloading a fresh copy of the Makefile.common"
-# 	# It will use the cached version in case the pull fails.
+
+# .EXPORT_ALL_VARIABLES:
+# SOURCE := https://raw.githubusercontent.com/prometheus/common/master/Makefile.common
+
+# %:	download
+# 	@$(MAKE) -f Makefile.common $@
+
+# download :
+# 	@echo ">> downloading a fresh copy of $(SOURCE)"
+# 	# If the pull fails it will use the local cached version.
 # 	@# -f do NOT overwrite the file in case of a network error. Keep cached copy!
-# 	@curl https://raw.githubusercontent.com/prometheus/common/master/Makefile.common -s -f -o Makefile.common || true  
-# 	@make -f Makefile.common $@
-# local-rule:
-# 	@echo ">> runing a local rules which has a priority over the catch all rule"
-
-# Any env to be passed down the Makefile.common should be put before the "catch all" rule in the format
-# export DOCKER_IMAGE_NAME       ?= prometheus
-
+# 	@curl $(SOURCE) -s -f -o Makefile.common || true
 
 
 # Ensure GOBIN is not set during build so that promu is installed to the correct path

--- a/scripts/check_license.sh
+++ b/scripts/check_license.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+#
+# Copyright 2018 The Prometheus Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+check_license() {
+  local file=""
+  for file in $(find . -type f -iname '*.go' ! -path './vendor/*'); do
+    head -n3 "${file}" | grep -Eq "(Copyright|generated|GENERATED)" || echo "  ${file}"
+  done
+}
+
+licRes=$(check_license)
+
+if [ -n "${licRes}" ]; then
+  echo "license header checking failed:"
+  echo "${licRes}"
+  exit 1
+fi


### PR DESCRIPTION
an idea how to reuse common rules in a Makefile across projects
fixes https://github.com/prometheus/prometheus/issues/3904

the common makefile is to gather common rules
it will be pulled down by projects that want to use it but each project will also keep a local cached copy Makefile.common  so a developper can still work offline.

here is how the prometheus makefile will look like.
https://github.com/prometheus/prometheus/pull/3978/files

cc @brian-brazil 