### PR TITLE
Replace yaml Unmarshal workaround with UnmarshalStrict.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -11,23 +11,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// This package no longer handles safe yaml parsing. In order to
+// ensure correct yaml unmarshalling, use "yaml.UnmarshalStrict()".
+
 package config
-
-import (
-	"fmt"
-	"strings"
-)
-
-func checkOverflow(m map[string]interface{}, ctx string) error {
-	if len(m) > 0 {
-		var keys []string
-		for k := range m {
-			keys = append(keys, k)
-		}
-		return fmt.Errorf("unknown fields in %s: %s", ctx, strings.Join(keys, ", "))
-	}
-	return nil
-}
 
 // Secret special type for storing secrets.
 type Secret string

--- a/config/http_config.go
+++ b/config/http_config.go
@@ -32,9 +32,6 @@ type BasicAuth struct {
 	Username     string `yaml:"username"`
 	Password     Secret `yaml:"password,omitempty"`
 	PasswordFile string `yaml:"password_file,omitempty"`
-
-	// Catches all undefined fields and must be empty after parsing.
-	XXX map[string]interface{} `yaml:",inline"`
 }
 
 // URL is a custom URL type that allows validation at configuration load time.
@@ -77,9 +74,6 @@ type HTTPClientConfig struct {
 	ProxyURL URL `yaml:"proxy_url,omitempty"`
 	// TLSConfig to use to connect to the targets.
 	TLSConfig TLSConfig `yaml:"tls_config,omitempty"`
-
-	// Catches all undefined fields and must be empty after parsing.
-	XXX map[string]interface{} `yaml:",inline"`
 }
 
 // Validate validates the HTTPClientConfig to check only one of BearerToken,
@@ -103,25 +97,16 @@ func (c *HTTPClientConfig) Validate() error {
 // UnmarshalYAML implements the yaml.Unmarshaler interface
 func (c *HTTPClientConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	type plain HTTPClientConfig
-	err := unmarshal((*plain)(c))
-	if err != nil {
+	if err := unmarshal((*plain)(c)); err != nil {
 		return err
 	}
-	err = c.Validate()
-	if err != nil {
-		return c.Validate()
-	}
-	return checkOverflow(c.XXX, "http_client_config")
+	return c.Validate()
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
 func (a *BasicAuth) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	type plain BasicAuth
-	err := unmarshal((*plain)(a))
-	if err != nil {
-		return err
-	}
-	return checkOverflow(a.XXX, "basic_auth")
+	return unmarshal((*plain)(a))
 }
 
 // NewClient returns a http.Client using the specified http.RoundTripper.
@@ -318,18 +303,12 @@ type TLSConfig struct {
 	ServerName string `yaml:"server_name,omitempty"`
 	// Disable target certificate validation.
 	InsecureSkipVerify bool `yaml:"insecure_skip_verify"`
-
-	// Catches all undefined fields and must be empty after parsing.
-	XXX map[string]interface{} `yaml:",inline"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
 func (c *TLSConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	type plain TLSConfig
-	if err := unmarshal((*plain)(c)); err != nil {
-		return err
-	}
-	return checkOverflow(c.XXX, "TLS config")
+	return unmarshal((*plain)(c))
 }
 
 func (c HTTPClientConfig) String() string {

--- a/config/http_config_test.go
+++ b/config/http_config_test.go
@@ -542,7 +542,7 @@ func TestInvalidHTTPConfigs(t *testing.T) {
 // LoadHTTPConfig parses the YAML input s into a HTTPClientConfig.
 func LoadHTTPConfig(s string) (*HTTPClientConfig, error) {
 	cfg := &HTTPClientConfig{}
-	err := yaml.Unmarshal([]byte(s), cfg)
+	err := yaml.UnmarshalStrict([]byte(s), cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/config/tls_config_test.go
+++ b/config/tls_config_test.go
@@ -28,8 +28,8 @@ func LoadTLSConfig(filename string) (*tls.Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	cfg := &TLSConfig{}
-	if err = yaml.UnmarshalStrict(content, cfg); err != nil {
+	cfg := TLSConfig{}
+	if err = yaml.UnmarshalStrict(content, &cfg); err != nil {
 		return nil, err
 	}
 	return NewTLSConfig(&cfg)

--- a/config/tls_config_test.go
+++ b/config/tls_config_test.go
@@ -28,8 +28,8 @@ func LoadTLSConfig(filename string) (*tls.Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	cfg := TLSConfig{}
-	if err = yaml.Unmarshal(content, &cfg); err != nil {
+	cfg := &TLSConfig{}
+	if err = yaml.UnmarshalStrict(content, cfg); err != nil {
 		return nil, err
 	}
 	return NewTLSConfig(&cfg)


### PR DESCRIPTION
This resolves #126.
As with prometheus/prometheus/pull/4033, after updating the yaml vendor package, `checkOverflow()` is no longer needed since `UnmarshalStrict()` covers duplicate and unknown fields in yaml files.
Also some cleanup after deleting some -no longer necessary- variables and `checkOverflow()` calls.
@fabxc, there are no major changes, so I believe this can be merged right after prometheus/prometheus/pull/4033, if everything looks good of course.
cc @krasi-georgiev 