### PR TITLE
Fix typos found by codespell

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ components and libraries.
 * **log**: A logging wrapper around [logrus](https://github.com/sirupsen/logrus)
 * **model**: Shared data structures
 * **route**: A routing wrapper around [httprouter](https://github.com/julienschmidt/httprouter) using `context.Context`
-* **version**: Version informations and metric
+* **version**: Version information and metrics

--- a/expfmt/decode.go
+++ b/expfmt/decode.go
@@ -164,9 +164,9 @@ func (sd *SampleDecoder) Decode(s *model.Vector) error {
 }
 
 // ExtractSamples builds a slice of samples from the provided metric
-// families. If an error occurs during sample extraction, it continues to
+// families. If an error occurrs during sample extraction, it continues to
 // extract from the remaining metric families. The returned error is the last
-// error that has occured.
+// error that has occurred.
 func ExtractSamples(o *DecodeOptions, fams ...*dto.MetricFamily) (model.Vector, error) {
 	var (
 		all     model.Vector

--- a/expfmt/text_parse.go
+++ b/expfmt/text_parse.go
@@ -556,8 +556,8 @@ func (p *TextParser) readTokenUntilWhitespace() {
 // byte considered is the byte already read (now in p.currentByte).  The first
 // newline byte encountered is still copied into p.currentByte, but not into
 // p.currentToken. If recognizeEscapeSequence is true, two escape sequences are
-// recognized: '\\' tranlates into '\', and '\n' into a line-feed character. All
-// other escape sequences are invalid and cause an error.
+// recognized: '\\' translates into '\', and '\n' into a line-feed character.
+// All other escape sequences are invalid and cause an error.
 func (p *TextParser) readTokenUntilNewline(recognizeEscapeSequence bool) {
 	p.currentToken.Reset()
 	escaped := false

--- a/model/silence.go
+++ b/model/silence.go
@@ -59,8 +59,8 @@ func (m *Matcher) Validate() error {
 	return nil
 }
 
-// Silence defines the representation of a silence definiton
-// in the Prometheus eco-system.
+// Silence defines the representation of a silence definition in the Prometheus
+// eco-system.
 type Silence struct {
 	ID uint64 `json:"id,omitempty"`
 

--- a/model/value.go
+++ b/model/value.go
@@ -100,7 +100,7 @@ func (s *SamplePair) UnmarshalJSON(b []byte) error {
 }
 
 // Equal returns true if this SamplePair and o have equal Values and equal
-// Timestamps. The sematics of Value equality is defined by SampleValue.Equal.
+// Timestamps. The semantics of Value equality is defined by SampleValue.Equal.
 func (s *SamplePair) Equal(o *SamplePair) bool {
 	return s == o || (s.Value.Equal(o.Value) && s.Timestamp.Equal(o.Timestamp))
 }
@@ -117,7 +117,7 @@ type Sample struct {
 }
 
 // Equal compares first the metrics, then the timestamp, then the value. The
-// sematics of value equality is defined by SampleValue.Equal.
+// semantics of value equality is defined by SampleValue.Equal.
 func (s *Sample) Equal(o *Sample) bool {
 	if s == o {
 		return true


### PR DESCRIPTION
@fabxc I've fixed some trivial typos while reading parts of the code.

Signed-off-by: Karsten Weiss <knweiss@gmail.com>