### PR TITLE
Adding json support for model.Duration

### DIFF
--- a/model/time.go
+++ b/model/time.go
@@ -14,6 +14,7 @@
 package model
 
 import (
+	"encoding/json"
 	"fmt"
 	"math"
 	"regexp"
@@ -253,6 +254,25 @@ func (d Duration) MarshalYAML() (interface{}, error) {
 func (d *Duration) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var s string
 	if err := unmarshal(&s); err != nil {
+		return err
+	}
+	dur, err := ParseDuration(s)
+	if err != nil {
+		return err
+	}
+	*d = dur
+	return nil
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (d Duration) MarshalJSON() (interface{}, error) {
+	return json.Marshal(d)
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+func (d *Duration) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
 		return err
 	}
 	dur, err := ParseDuration(s)


### PR DESCRIPTION
Otherwise it will attempt to unmarshal as time.Duration int64 and panic because
ParseDuration will not be called.

Ex,
```
rulefmt.RuleGroups.Groups: []rulefmt.RuleGroup: rulefmt.RuleGroup.Rules: []rulefmt.Rule: rulefmt.Rule.For: readUint64: unexpected character: \xff, error found in #10 byte of ...|n\",\"for\":\"5m\",\"label|..., bigger context ...|ut(instance) (rate(requests_total[5m]))\\n\",\"for\":\"5m\",\"labels\":{\"severity\":\"critical\"}}]}]}}\n|..."}
```