### PR TITLE
promlog: add support for json logger

### DIFF
--- a/promlog/flag/flag.go
+++ b/promlog/flag/flag.go
@@ -25,9 +25,19 @@ const LevelFlagName = "log.level"
 // LevelFlagHelp is the help description for the log.level flag.
 const LevelFlagHelp = "Only log messages with the given severity or above. One of: [debug, info, warn, error]"
 
+// FormatFlagName is the canonical flag name to configure the log format
+// within Prometheus projects.
+const FormatFlagName = "log.format"
+
+// FormatFlagHelp is the help description for the log.format flag.
+const FormatFlagHelp = "Output format of log messages. One of: [logfmt, json]"
+
 // AddFlags adds the flags used by this package to the Kingpin application.
 // To use the default Kingpin application, call AddFlags(kingpin.CommandLine)
-func AddFlags(a *kingpin.Application, logLevel *promlog.AllowedLevel) {
+func AddFlags(a *kingpin.Application, config *promlog.Config) {
 	a.Flag(LevelFlagName, LevelFlagHelp).
-		Default("info").SetValue(logLevel)
+		Default("info").SetValue(config.Level)
+
+	a.Flag(FormatFlagName, FormatFlagHelp).
+		Default("logfmt").SetValue(config.Format)
 }

--- a/promlog/log.go
+++ b/promlog/log.go
@@ -53,11 +53,42 @@ func (l *AllowedLevel) Set(s string) error {
 	return nil
 }
 
-// New returns a new leveled oklog logger in the logfmt format. Each logged line will be annotated
+// AllowedFormat is a settable identifier for the output format that the logger can have.
+type AllowedFormat struct {
+	s string
+}
+
+func (f *AllowedFormat) String() string {
+	return f.s
+}
+
+// Set updates the value of the allowed format.
+func (f *AllowedFormat) Set(s string) error {
+	switch s {
+	case "logfmt", "json":
+		f.s = s
+	default:
+		return errors.Errorf("unrecognized log format %q", s)
+	}
+	return nil
+}
+
+type Config struct {
+	Level  *AllowedLevel
+	Format *AllowedFormat
+}
+
+// New returns a new leveled oklog logger. Each logged line will be annotated
 // with a timestamp. The output always goes to stderr.
-func New(al AllowedLevel) log.Logger {
-	l := log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
-	l = level.NewFilter(l, al.o)
+func New(config *Config) log.Logger {
+	var l log.Logger
+	if config.Format.s == "logfmt" {
+		l = log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
+	} else {
+		l = log.NewJSONLogger(log.NewSyncWriter(os.Stderr))
+	}
+
+	l = level.NewFilter(l, config.Level.o)
 	l = log.With(l, "ts", log.DefaultTimestampUTC, "caller", log.DefaultCaller)
 	return l
 }


### PR DESCRIPTION
~~**Note**: this changes the signature of promlog.New, so any repos that use this method in prometheus will need to be changed and will need to include the `log.format` flag.~~

~~As far as I'm aware, functions whose signatures are affected (i.e. `promlog.New` and `flag.AddFlags`) are used in `prometheus/cmd/prometheus/main.go`, `alertmanager/cmd/alertmanager/main.go`, and `blackbox_exporter/main.go`, so these will need to be updated at some point, at least when the vendor directories are updated.~~

Fixes issue: https://github.com/prometheus/prometheus/issues/3219

Should I include some sort of test for this feature (and maybe the log level flag as well)?

@krasi-georgiev 