### PR TITLE
Support upstream time.ParseDuration (#117)

### DIFF
--- a/expfmt/text_parse.go
+++ b/expfmt/text_parse.go
@@ -359,7 +359,7 @@ func (p *TextParser) startLabelValue() stateFn {
 		}
 		return p.readingValue
 	default:
-		p.parseError(fmt.Sprintf("unexpected end of label value %q", p.currentLabelPair.Value))
+		p.parseError(fmt.Sprintf("unexpected end of label value %q", p.currentLabelPair.GetValue()))
 		return nil
 	}
 }

--- a/model/time.go
+++ b/model/time.go
@@ -182,6 +182,10 @@ var durationRE = regexp.MustCompile("^([0-9]+)(y|w|d|h|m|s|ms)$")
 func ParseDuration(durationStr string) (Duration, error) {
 	matches := durationRE.FindStringSubmatch(durationStr)
 	if len(matches) != 3 {
+		// If single unit validation fails, still support time.ParseDuration
+		if d, err := time.ParseDuration(durationStr); err == nil {
+			return Duration(d), nil
+		}
 		return 0, fmt.Errorf("not a valid duration string: %q", durationStr)
 	}
 	var (


### PR DESCRIPTION
This change supports model time.ParseDuration and is backwards
compatible with upstream.