### PR TITLE
Update HTTPConfig with KeepAlive setting.

### DIFF
--- a/config/http_config_test.go
+++ b/config/http_config_test.go
@@ -93,6 +93,7 @@ func newTestServer(handler func(w http.ResponseWriter, r *http.Request)) (*httpt
 }
 
 func TestNewClientFromConfig(t *testing.T) {
+	fVal := false
 	var newClientValidConfig = []struct {
 		clientConfig HTTPClientConfig
 		handler      func(w http.ResponseWriter, r *http.Request)
@@ -117,6 +118,19 @@ func TestNewClientFromConfig(t *testing.T) {
 					KeyFile:            BarneyKeyNoPassPath,
 					ServerName:         "",
 					InsecureSkipVerify: false},
+			},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprint(w, ExpectedMessage)
+			},
+		}, {
+			clientConfig: HTTPClientConfig{
+				TLSConfig: TLSConfig{
+					CAFile:             TLSCAChainPath,
+					CertFile:           BarneyCertificatePath,
+					KeyFile:            BarneyKeyNoPassPath,
+					ServerName:         "",
+					InsecureSkipVerify: false},
+				KeepAlive: &fVal,
 			},
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				fmt.Fprint(w, ExpectedMessage)

--- a/config/testdata/http.conf.good.yml
+++ b/config/testdata/http.conf.good.yml
@@ -2,3 +2,4 @@ basic_auth:
   username: username
   password: "mysecret"
 proxy_url: "http://remote.host"
+keep_alive: false


### PR DESCRIPTION
In previous development of Prometheus, it has been possible to configure the KeepAlive settings of specific scrapes. However, that functionality was intentionally removed:

https://github.com/prometheus/prometheus/pull/3173

I'd be interested in reviving the discussion around this.

We attempt to scrape an endpoint that is behind a "black box" type load balancer, whose logic we don't really control. What we'd like to achieve is a roughly equal percent of the balanced resources receiving Prometheus requests to their `/metrics` endpoints. However, after some discussion with support on that product, we have determined that this won't work as long as the client (Prometheus in this case) is not sending `Connection: close` type requests.

The specific client I'd like to alter is the one created here:

https://github.com/prometheus/prometheus/blob/2bd510a63e48ac6bf4971d62199bdb1045c93f1a/scrape/scrape.go#L145-L149

I apologize if this is a dead discussion, and we have some ideas to make other workarounds. However, I do think it's a useful case for Prometheus to cover, I can imagine other endpoints that work better without HTTP keep-alive.

@fabxc 