### PR TITLE
promlog: add comment for Config

### DIFF
--- a/promlog/log.go
+++ b/promlog/log.go
@@ -73,6 +73,7 @@ func (f *AllowedFormat) Set(s string) error {
 	return nil
 }
 
+// Config is a struct containing configurable settings for the logger
 type Config struct {
 	Level  *AllowedLevel
 	Format *AllowedFormat


### PR DESCRIPTION
Forgot to add a comment for the Config struct in #136; should satisfy any lint issues for people.