### PR TITLE
initialize flags in AddFlags

### DIFF
--- a/promlog/flag/flag.go
+++ b/promlog/flag/flag.go
@@ -35,11 +35,11 @@ const FormatFlagHelp = "Output format of log messages. One of: [logfmt, json]"
 // AddFlags adds the flags used by this package to the Kingpin application.
 // To use the default Kingpin application, call AddFlags(kingpin.CommandLine)
 func AddFlags(a *kingpin.Application, config *promlog.Config) {
-	config.Level = new(promlog.AllowedLevel)
+	config.Level = &promlog.AllowedLevel{}
 	a.Flag(LevelFlagName, LevelFlagHelp).
 		Default("info").SetValue(config.Level)
 
-	config.Format = new(promlog.AllowedFormat)
+	config.Format = &promlog.AllowedFormat{}
 	a.Flag(FormatFlagName, FormatFlagHelp).
 		Default("logfmt").SetValue(config.Format)
 }

--- a/promlog/flag/flag.go
+++ b/promlog/flag/flag.go
@@ -35,9 +35,11 @@ const FormatFlagHelp = "Output format of log messages. One of: [logfmt, json]"
 // AddFlags adds the flags used by this package to the Kingpin application.
 // To use the default Kingpin application, call AddFlags(kingpin.CommandLine)
 func AddFlags(a *kingpin.Application, config *promlog.Config) {
+	config.Level = new(promlog.AllowedLevel)
 	a.Flag(LevelFlagName, LevelFlagHelp).
 		Default("info").SetValue(config.Level)
 
+	config.Format = new(promlog.AllowedFormat)
 	a.Flag(FormatFlagName, FormatFlagHelp).
 		Default("logfmt").SetValue(config.Format)
 }


### PR DESCRIPTION
Allocate and initialize pointers for the flags in promlog Config structs; this way clients don't need to worry about setting these, and only need to initialize the config itself.