### PR TITLE
version: Add ability to get a User-Agent value

### DIFF
--- a/version/info.go
+++ b/version/info.go
@@ -31,6 +31,8 @@ var (
 	BuildUser string
 	BuildDate string
 	GoVersion = runtime.Version()
+	Product   = "Prometheus-common"
+	userAgent = fmt.Sprintf("%s/%s", Product, Version)
 )
 
 // NewCollector returns a collector which exports metrics about current version information.
@@ -86,4 +88,15 @@ func Info() string {
 // BuildContext returns goVersion, buildUser and buildDate information.
 func BuildContext() string {
 	return fmt.Sprintf("(go=%s, user=%s, date=%s)", GoVersion, BuildUser, BuildDate)
+}
+
+// UAWithProduct returns a string that can be used for User-Agent headers on HTTP requests.
+// An empty product returns the User-Agent. One or more arguments will get appended to the
+// value, space separated. The format of the User-Agent header is described in RFC 2616.
+func UAWithProduct(products ...string) string {
+	if len(products) == 0 {
+		return userAgent
+	}
+
+	return fmt.Sprintf("%s %s", userAgent, strings.Join(products, " "))
 }


### PR DESCRIPTION
This is a follow-up based on discussion in prometheus/prometheus#4891

This introduces the `userAgent` as an unexported variable which can be
gotten and transformed with `UAWithProduct`, appending product tokens
as specified in RFC 2616:

```
User-Agent     = "User-Agent" ":" 1*( product | comment )
product         = token ["/" product-version]
product-version = token
token           = 1*<any CHAR except CTLs or separators>
```

The ability to add comments was left out as it seems less useful in the
context of Prometheus.

The idea is to use this in things like prometheus/storage/remote.Client
and the different service discovery mechanisms to get consistent User-Agent
headers everywhere. For example, the remote writer could set a header
using something like `version.UAWithProduct("remote-write/0.10.0")`
to get a complete header in the form of `Prometheus/2.25.0
remote-write/0.10.0`.