### PR TITLE
Use fixed length millisecond timestamp format for logs

### DIFF
--- a/promlog/log.go
+++ b/promlog/log.go
@@ -18,10 +18,21 @@ package promlog
 
 import (
 	"os"
+	"time"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
+)
+
+var (
+	// This timestamp format differs from RFC3339Nano by using .000 instead
+	// of .999999999 which changes the timestamp from 9 variable to 3 fixed
+	// decimals (.130 instead of .130987456).
+	timestampFormat = log.TimestampFormat(
+		func() time.Time { return time.Now().UTC() },
+		"2006-01-02T15:04:05.000Z07:00",
+	)
 )
 
 // AllowedLevel is a settable identifier for the minimum level a log entry
@@ -90,6 +101,6 @@ func New(config *Config) log.Logger {
 	}
 
 	l = level.NewFilter(l, config.Level.o)
-	l = log.With(l, "ts", log.DefaultTimestampUTC, "caller", log.DefaultCaller)
+	l = log.With(l, "ts", timestampFormat, "caller", log.DefaultCaller)
 	return l
 }


### PR DESCRIPTION
Port https://github.com/prometheus/prometheus/pull/5225 over to common