### PR TITLE
travis: minimum version is now Go 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 # Supported Go versions are synced with github.com/prometheus/client_golang.
 go:
-  - 1.7.x
   - 1.8.x
   - 1.9.x
   - 1.10.x


### PR DESCRIPTION
Signed-off-by: Matt Layher <mdlayher@gmail.com>

See also https://github.com/prometheus/client_golang/pull/546.