### PR TITLE
config: set TLSHandshakeTimeout in HTTP transport

### DIFF
--- a/config/http_config.go
+++ b/config/http_config.go
@@ -145,7 +145,9 @@ func NewRoundTripperFromConfig(cfg HTTPClientConfig, name string) (http.RoundTri
 			DisableCompression:  true,
 			// 5 minutes is typically above the maximum sane scrape interval. So we can
 			// use keepalive for all configurations.
-			IdleConnTimeout: 5 * time.Minute,
+			IdleConnTimeout:       5 * time.Minute,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ExpectContinueTimeout: 1 * time.Second,
 			DialContext: conntrack.NewDialContextFunc(
 				conntrack.DialWithTracing(),
 				conntrack.DialWithName(name),


### PR DESCRIPTION
If omitted (i.e. zero), TLS handshakes never timeout, which means TCP
connections (and their associated goroutines) can stay alive forever.

Also set `ExpectContinueTimeout`, so that both have the same value as in
`http.DefaultTransport`.

See prometheus/prometheus#5394.