### PR TITLE
Don't panic when route.Param has no binding.

### DIFF
--- a/route/route.go
+++ b/route/route.go
@@ -22,9 +22,13 @@ import (
 
 type param string
 
-// Param returns param p for the context.
+// Param returns param p for the context, or the empty string when
+// param does not exist in context.
 func Param(ctx context.Context, p string) string {
-	return ctx.Value(param(p)).(string)
+	if v, ok := ctx.Value(param(p)).(string); ok {
+		return v
+	}
+	return ""
 }
 
 // WithParam returns a new context with param p set to v.

--- a/route/route_test.go
+++ b/route/route_test.go
@@ -93,6 +93,23 @@ func TestContextWithValue(t *testing.T) {
 	router.ServeHTTP(nil, r)
 }
 
+func TestContextWithoutValue(t *testing.T) {
+	router := New()
+	router.Get("/test", func(w http.ResponseWriter, r *http.Request) {
+		want := ""
+		got := Param(r.Context(), "foo")
+		if want != got {
+			t.Fatalf("Unexpected context value: want %q, got %q", want, got)
+		}
+	})
+
+	r, err := http.NewRequest("GET", "http://localhost:9090/test", nil)
+	if err != nil {
+		t.Fatalf("Error building test request: %s", err)
+	}
+	router.ServeHTTP(nil, r)
+}
+
 func TestInstrumentation(t *testing.T) {
 	var got string
 	cases := []struct {


### PR DESCRIPTION
I've adopted route/common for a Prom related project, and had panics
due to a middleware attempting to grab a Param that had no binding in
the URL path in some cases.

I do like the safety aspect of panicing here, but strings have a
useful zero-value of "", which seems like an appropriate, and better
choice for this functionality.

(This will aide in
https://github.com/prometheus/pushgateway/issues/149 as some paths
don't have a *labels binding, but probably want to share some of the
same processing of labels code.)

cc / @brian-brazil 