### PR TITLE
Make `route.Param` panic on something else than a string

### DIFF
--- a/route/route.go
+++ b/route/route.go
@@ -25,8 +25,8 @@ type param string
 // Param returns param p for the context, or the empty string when
 // param does not exist in context.
 func Param(ctx context.Context, p string) string {
-	if v, ok := ctx.Value(param(p)).(string); ok {
-		return v
+	if v := ctx.Value(param(p)); v != nil {
+		return v.(string)
 	}
 	return ""
 }


### PR DESCRIPTION
As discussed in #181, the values in the context should always be
strings, but this makes sure of it, while the previous implementation
would return an empty string if somehow a non-string value made it
into the context.

This got accidentally steamrolled in the merge of #181. Not a big deal, but now that we have discussed it at length, let's also have it.