### PR TITLE
Implement common file server to return consistent Content-Type

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,5 @@ components and libraries.
 * **log**: A logging wrapper around [logrus](https://github.com/sirupsen/logrus)
 * **model**: Shared data structures
 * **route**: A routing wrapper around [httprouter](https://github.com/julienschmidt/httprouter) using `context.Context`
+* **server**: Common servers
 * **version**: Version information and metrics

--- a/server/static_file_server.go
+++ b/server/static_file_server.go
@@ -1,0 +1,43 @@
+// Copyright 2019 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"net/http"
+	"path/filepath"
+)
+
+func StaticFileServer(root http.FileSystem) http.Handler {
+	return &staticFileHandler{
+		root: root,
+	}
+}
+
+type staticFileHandler struct {
+	root http.FileSystem
+}
+
+func (h *staticFileHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	fileExt := filepath.Ext(r.URL.Path)
+
+	switch fileExt {
+	case ".js":
+		w.Header().Set("Content-Type", "application/javascript")
+	case ".css":
+		w.Header().Set("Content-Type", "text/css")
+	}
+
+	fs := http.FileServer(h.root)
+	fs.ServeHTTP(w, r)
+}

--- a/server/static_file_server.go
+++ b/server/static_file_server.go
@@ -18,26 +18,24 @@ import (
 	"path/filepath"
 )
 
+var mimeTypes = map[string]string{
+	".js":  "application/javascript",
+	".css": "text/css",
+	".png": "image/png",
+	".jpg": "image/jpeg",
+	".gif": "image/gif",
+}
+
 func StaticFileServer(root http.FileSystem) http.Handler {
-	return &staticFileHandler{
-		root: root,
-	}
-}
+	return http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			fileExt := filepath.Ext(r.URL.Path)
 
-type staticFileHandler struct {
-	root http.FileSystem
-}
+			if t, ok := mimeTypes[fileExt]; ok {
+				w.Header().Set("Content-Type", t)
+			}
 
-func (h *staticFileHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	fileExt := filepath.Ext(r.URL.Path)
-
-	switch fileExt {
-	case ".js":
-		w.Header().Set("Content-Type", "application/javascript")
-	case ".css":
-		w.Header().Set("Content-Type", "text/css")
-	}
-
-	fs := http.FileServer(h.root)
-	fs.ServeHTTP(w, r)
+			http.FileServer(root).ServeHTTP(w, r)
+		},
+	)
 }

--- a/server/static_file_server_test.go
+++ b/server/static_file_server_test.go
@@ -38,13 +38,28 @@ func TestServeHttp(t *testing.T) {
 		},
 		{
 			name:        "javascript",
-			path:        "index.js",
+			path:        "test.js",
 			contentType: "application/javascript",
 		},
 		{
 			name:        "css",
-			path:        "index.css",
+			path:        "test.css",
 			contentType: "text/css",
+		},
+		{
+			name:        "png",
+			path:        "test.png",
+			contentType: "image/png",
+		},
+		{
+			name:        "jpg",
+			path:        "test.jpg",
+			contentType: "image/jpeg",
+		},
+		{
+			name:        "gif",
+			path:        "test.gif",
+			contentType: "image/gif",
 		},
 	}
 

--- a/server/static_file_server_test.go
+++ b/server/static_file_server_test.go
@@ -1,0 +1,68 @@
+// Copyright 2019 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type dummyFileSystem struct{}
+
+func (fs dummyFileSystem) Open(path string) (http.File, error) {
+	return http.Dir(".").Open(".")
+}
+
+func TestServeHttp(t *testing.T) {
+	cases := []struct {
+		name        string
+		path        string
+		contentType string
+	}{
+		{
+			name:        "normal file",
+			path:        "index.html",
+			contentType: "",
+		},
+		{
+			name:        "javascript",
+			path:        "index.js",
+			contentType: "application/javascript",
+		},
+		{
+			name:        "css",
+			path:        "index.css",
+			contentType: "text/css",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			req, err := http.NewRequest("GET", "http://localhost/"+c.path, nil)
+
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			s := StaticFileServer(dummyFileSystem{})
+			s.ServeHTTP(rr, req)
+
+			if rr.Header().Get("Content-Type") != c.contentType {
+				t.Fatalf("Unexpected Content-Type: %s", rr.Header().Get("Content-Type"))
+			}
+		})
+	}
+}


### PR DESCRIPTION
When `/etc/mime.types` has an unusual mime type, Content-Type of response becomes the type and you may get an unexpected result.
This server returns consistent Content-Type header for js and css files

Signed-off-by: mrasu <m.rasu.hitsuji@gmail.com>