### PR TITLE
Add json convert function for Duration type

### DIFF
--- a/model/time.go
+++ b/model/time.go
@@ -14,6 +14,7 @@
 package model
 
 import (
+	"encoding/json"
 	"fmt"
 	"math"
 	"regexp"
@@ -261,4 +262,19 @@ func (d *Duration) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	}
 	*d = dur
 	return nil
+}
+
+func (d *Duration) UnmarshalJSON(data []byte) error {
+	var s string
+	json.Unmarshal(data, &s)
+	dur, err := ParseDuration(s)
+	if err != nil {
+		return err
+	}
+	*d = dur
+	return nil
+}
+
+func (d Duration) MarshalJSON() ([]byte, error) {
+	return json.Marshal(d.String())
 }


### PR DESCRIPTION
I extended alertmanager api for list and edit its config. The api received a json request and returned a json result.
I found that Duration type didn't support json Unmarshal/Marshal. As a result, it would raise error "json: cannot unmarshal string into Go struct field Route.group_interval of type model.Duration " for edit api. The list api returned 10000 but not "10s" if the config had "group_wait: 10s" or other Duration type config.
I hope this commit could be helpful, if others have the same requirement.

Signed-off-by: lvjiawei <lvjiawei@cmss.chinamobile.com>