### PR TITLE
Allow TLS renegotiation

### DIFF
--- a/config/http_config.go
+++ b/config/http_config.go
@@ -291,7 +291,7 @@ func cloneRequest(r *http.Request) *http.Request {
 
 // NewTLSConfig creates a new tls.Config from the given TLSConfig.
 func NewTLSConfig(cfg *TLSConfig) (*tls.Config, error) {
-	tlsConfig := &tls.Config{InsecureSkipVerify: cfg.InsecureSkipVerify}
+	tlsConfig := &tls.Config{InsecureSkipVerify: cfg.InsecureSkipVerify, Renegotiation: tls.RenegotiateFreelyAsClient}
 
 	// If a CA cert is provided then let's read it in so we can validate the
 	// scrape target's certificate properly.


### PR DESCRIPTION
This patch is to address an interop issue against Microsoft IIS. If, for example, one tries to use client certificates against such a server in blackbox-exporter, there will always be a TLS renegotiation error. The problem has been addressed a while ago in Go by adding the 'Renegotiation' parameter.

As an alternative, this could be made configurable, but I am no Go expert.
