### PR TITLE
fix all issues reported by the default golangci linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,0 @@
-# Run only staticcheck for now. Additional linters will be enabled one-by-one.
-linters:
-  enable:
-  - staticcheck
-  disable-all: true

--- a/config/http_config_test.go
+++ b/config/http_config_test.go
@@ -327,13 +327,19 @@ func TestBearerAuthRoundTripper(t *testing.T) {
 	bearerAuthRoundTripper := NewBearerAuthRoundTripper(BearerToken, fakeRoundTripper)
 	request, _ := http.NewRequest("GET", "/hitchhiker", nil)
 	request.Header.Set("User-Agent", "Douglas Adams mind")
-	bearerAuthRoundTripper.RoundTrip(request)
+	_, err := bearerAuthRoundTripper.RoundTrip(request)
+	if err != nil {
+		t.Errorf("unexpected error while executing RoundTrip: %s", err.Error())
+	}
 
 	// Should honor already Authorization header set.
 	bearerAuthRoundTripperShouldNotModifyExistingAuthorization := NewBearerAuthRoundTripper(newBearerToken, fakeRoundTripper)
 	request, _ = http.NewRequest("GET", "/hitchhiker", nil)
 	request.Header.Set("Authorization", ExpectedBearer)
-	bearerAuthRoundTripperShouldNotModifyExistingAuthorization.RoundTrip(request)
+	_, err = bearerAuthRoundTripperShouldNotModifyExistingAuthorization.RoundTrip(request)
+	if err != nil {
+		t.Errorf("unexpected error while executing RoundTrip: %s", err.Error())
+	}
 }
 
 func TestBearerAuthFileRoundTripper(t *testing.T) {
@@ -349,13 +355,19 @@ func TestBearerAuthFileRoundTripper(t *testing.T) {
 	bearerAuthRoundTripper := NewBearerAuthFileRoundTripper(BearerTokenFile, fakeRoundTripper)
 	request, _ := http.NewRequest("GET", "/hitchhiker", nil)
 	request.Header.Set("User-Agent", "Douglas Adams mind")
-	bearerAuthRoundTripper.RoundTrip(request)
+	_, err := bearerAuthRoundTripper.RoundTrip(request)
+	if err != nil {
+		t.Errorf("unexpected error while executing RoundTrip: %s", err.Error())
+	}
 
 	// Should honor already Authorization header set.
 	bearerAuthRoundTripperShouldNotModifyExistingAuthorization := NewBearerAuthFileRoundTripper(MissingBearerTokenFile, fakeRoundTripper)
 	request, _ = http.NewRequest("GET", "/hitchhiker", nil)
 	request.Header.Set("Authorization", ExpectedBearer)
-	bearerAuthRoundTripperShouldNotModifyExistingAuthorization.RoundTrip(request)
+	_, err = bearerAuthRoundTripperShouldNotModifyExistingAuthorization.RoundTrip(request)
+	if err != nil {
+		t.Errorf("unexpected error while executing RoundTrip: %s", err.Error())
+	}
 }
 
 func TestTLSConfig(t *testing.T) {

--- a/config/tls_config_test.go
+++ b/config/tls_config_test.go
@@ -58,7 +58,7 @@ func TestValidTLSConfig(t *testing.T) {
 		}
 		// non-nil functions are never equal.
 		got.GetClientCertificate = nil
-		if !reflect.DeepEqual(*got, *cfg.config) {
+		if !reflect.DeepEqual(got, cfg.config) {
 			t.Fatalf("%v: unexpected config result: \n\n%v\n expected\n\n%v", cfg.filename, got, cfg.config)
 		}
 	}

--- a/model/alert_test.go
+++ b/model/alert_test.go
@@ -109,7 +109,7 @@ func TestAlertValidate(t *testing.T) {
 			t.Errorf("%d. Expected error %q but got none", i, c.err)
 			continue
 		}
-		if c.err == "" && err != nil {
+		if c.err == "" {
 			t.Errorf("%d. Expected no error but got %q", i, err)
 			continue
 		}

--- a/model/silence_test.go
+++ b/model/silence_test.go
@@ -76,7 +76,7 @@ func TestMatcherValidate(t *testing.T) {
 			t.Errorf("%d. Expected error %q but got none", i, c.err)
 			continue
 		}
-		if c.err == "" && err != nil {
+		if c.err == "" {
 			t.Errorf("%d. Expected no error but got %q", i, err)
 			continue
 		}
@@ -227,7 +227,7 @@ func TestSilenceValidate(t *testing.T) {
 			t.Errorf("%d. Expected error %q but got none", i, c.err)
 			continue
 		}
-		if c.err == "" && err != nil {
+		if c.err == "" {
 			t.Errorf("%d. Expected no error but got %q", i, err)
 			continue
 		}


### PR DESCRIPTION
This fixes all the issues reported by the default linter tools used by golangci.
