### PR TITLE
Require Go 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: go
 # Supported Go versions are synced with github.com/prometheus/client_golang.
 go:
-  - 1.7.x
-  - 1.8.x
   - 1.9.x
   - 1.10.x
   - 1.11.x


### PR DESCRIPTION
client_golang requires 1.9, so we can drop the earlier ones.

Older versions are causing test failures, so clean this up.

@beorn7 