### PR TITLE
Make `version.NewCollector` more idiomatic

### DIFF
--- a/version/info.go
+++ b/version/info.go
@@ -34,8 +34,8 @@ var (
 )
 
 // NewCollector returns a collector which exports metrics about current version information.
-func NewCollector(program string) *prometheus.GaugeVec {
-	buildInfo := prometheus.NewGaugeVec(
+func NewCollector(program string) prometheus.Collector {
+	return prometheus.NewGaugeFunc(
 		prometheus.GaugeOpts{
 			Namespace: program,
 			Name:      "build_info",
@@ -43,11 +43,15 @@ func NewCollector(program string) *prometheus.GaugeVec {
 				"A metric with a constant '1' value labeled by version, revision, branch, and goversion from which %s was built.",
 				program,
 			),
+			ConstLabels: prometheus.Labels{
+				"version":   Version,
+				"revision":  Revision,
+				"branch":    Branch,
+				"goversion": GoVersion,
+			},
 		},
-		[]string{"version", "revision", "branch", "goversion"},
+		func() float64 { return 1 },
 	)
-	buildInfo.WithLabelValues(Version, Revision, Branch, GoVersion).Set(1)
-	return buildInfo
 }
 
 // versionInfoTmpl contains the template used by Info.

--- a/version/info.go
+++ b/version/info.go
@@ -33,7 +33,8 @@ var (
 	GoVersion = runtime.Version()
 )
 
-// NewCollector returns a collector which exports metrics about current version information.
+// NewCollector returns a collector that exports metrics about current version
+// information.
 func NewCollector(program string) prometheus.Collector {
 	return prometheus.NewGaugeFunc(
 		prometheus.GaugeOpts{


### PR DESCRIPTION
Discussing a documentation request in client_golang (
https://github.com/prometheus/client_golang/issues/693 ), I realized
that the usage here in the `version` package is not as idiomatic as it
could be. Returning a `GaugeVec`, the metric value could easily be
changed.

To improve things, this could be done with a `NewConstMetric`, but I think the
currently best way for this is a `GaugeFunc`. It is a single statement now, 
it reads more nicely, and it
avoids misaligning the label values. Plus, it returns just a
`Collector`, so no misunderstanding what to do with it (like adding
more elements to the `GaugeVec` or changing the value).

I have checked all usages in the Prometheus GH org. They are all compatible with this change.