### PR TITLE
promlog: Avoid panic for new logger with empty config

### DIFF
--- a/promlog/log.go
+++ b/promlog/log.go
@@ -94,13 +94,15 @@ type Config struct {
 // with a timestamp. The output always goes to stderr.
 func New(config *Config) log.Logger {
 	var l log.Logger
-	if config.Format.s == "logfmt" {
-		l = log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
-	} else {
+	if config.Format != nil && config.Format.s == "json" {
 		l = log.NewJSONLogger(log.NewSyncWriter(os.Stderr))
+	} else {
+		l = log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
 	}
 
-	l = level.NewFilter(l, config.Level.o)
+	if config.Level != nil {
+		l = level.NewFilter(l, config.Level.o)
+	}
 	l = log.With(l, "ts", timestampFormat, "caller", log.DefaultCaller)
 	return l
 }

--- a/promlog/log_test.go
+++ b/promlog/log_test.go
@@ -1,0 +1,28 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package promlog
+
+import (
+	"testing"
+)
+
+// Make sure creating and using a logger with an empty configuration doesn't
+// result in a panic.
+func TestDefaultConfig(t *testing.T) {
+	logger := New(&Config{})
+
+	if err := logger.Log("hello", "world"); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Make sure that

```golang
promlog.New(&promlog.Config{})
```

doesn't panic. Instead, create a logger with reasonable defaults.

Signed-off-by: Benoît Knecht <bknecht@protonmail.ch>