### PR TITLE
Support 0 for model.Duration.

### DIFF
--- a/model/time.go
+++ b/model/time.go
@@ -186,7 +186,7 @@ var durationRE = regexp.MustCompile("^([0-9]+)(y|w|d|h|m|s|ms)$")
 // ParseDuration parses a string into a time.Duration, assuming that a year
 // always has 365d, a week always has 7d, and a day always has 24h.
 func ParseDuration(durationStr string) (Duration, error) {
-	// shortcut if the value is 0
+	// Special case: if we receive a "0" string we can directly return a zero value without further processing.
 	if durationStr == "0" {
 		return 0, nil
 	}

--- a/model/time.go
+++ b/model/time.go
@@ -186,7 +186,7 @@ var durationRE = regexp.MustCompile("^([0-9]+)(y|w|d|h|m|s|ms)$")
 // ParseDuration parses a string into a time.Duration, assuming that a year
 // always has 365d, a week always has 7d, and a day always has 24h.
 func ParseDuration(durationStr string) (Duration, error) {
-	// Special case: if we receive a "0" string we can directly return a zero value without further processing.
+	// Allow 0 without a unit.
 	if durationStr == "0" {
 		return 0, nil
 	}

--- a/model/time.go
+++ b/model/time.go
@@ -186,6 +186,10 @@ var durationRE = regexp.MustCompile("^([0-9]+)(y|w|d|h|m|s|ms)$")
 // ParseDuration parses a string into a time.Duration, assuming that a year
 // always has 365d, a week always has 7d, and a day always has 24h.
 func ParseDuration(durationStr string) (Duration, error) {
+	// shortcut if the value is 0
+	if durationStr == "0" {
+		return 0, nil
+	}
 	matches := durationRE.FindStringSubmatch(durationStr)
 	if len(matches) != 3 {
 		return 0, fmt.Errorf("not a valid duration string: %q", durationStr)

--- a/model/time_test.go
+++ b/model/time_test.go
@@ -90,8 +90,14 @@ func TestParseDuration(t *testing.T) {
 	var cases = []struct {
 		in  string
 		out time.Duration
+
+		expectedString string
 	}{
 		{
+			in:             "0",
+			out:            0,
+			expectedString: "0s",
+		}, {
 			in:  "0s",
 			out: 0,
 		}, {
@@ -126,7 +132,11 @@ func TestParseDuration(t *testing.T) {
 		if time.Duration(d) != c.out {
 			t.Errorf("Expected %v but got %v", c.out, d)
 		}
-		if d.String() != c.in {
+		expectedString := c.expectedString
+		if c.expectedString == "" {
+			expectedString = c.in
+		}
+		if d.String() != expectedString {
 			t.Errorf("Expected duration string %q but got %q", c.in, d.String())
 		}
 	}


### PR DESCRIPTION
This allows to pass the string "0" to parse a model.Duration. This is because `time.Duration` also support this zero value and so it is easier to interchange model.Duration with time.Duration.

time.Duration does parses 0 using this:

```
	// Special case: if all that is left is "0", this is zero.
	if s == "0" {
		return 0, nil
	}
```

see https://golang.org/src/time/format.go?s=40541:40587#L1389

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>