### PR TITLE
Json support duration

### DIFF
--- a/model/time.go
+++ b/model/time.go
@@ -279,7 +279,7 @@ func (d Duration) MarshalJSON() ([]byte, error) {
 	return json.Marshal(d.String())
 }
 
-// UnmarshalJSON implements the json.Marshaler interface for Duration.
+// UnmarshalJSON implements the json.Unmarshaler interface for Duration.
 func (d *Duration) UnmarshalJSON(data []byte) error {
 	var s string
 	err := json.Unmarshal(data, &s)
@@ -290,6 +290,6 @@ func (d *Duration) UnmarshalJSON(data []byte) error {
 	if err != nil {
 		return err
 	}
-	d = &dur
+	*d = dur
 	return nil
 }

--- a/model/time.go
+++ b/model/time.go
@@ -14,6 +14,7 @@
 package model
 
 import (
+	"encoding/json"
 	"fmt"
 	"math"
 	"regexp"
@@ -270,5 +271,25 @@ func (d *Duration) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return err
 	}
 	*d = dur
+	return nil
+}
+
+// MarshalJSON implements the json.Marshaler interface for Duration.
+func (d Duration) MarshalJSON() ([]byte, error) {
+	return json.Marshal(d.String())
+}
+
+// UnmarshalJSON implements the json.Marshaler interface for Duration.
+func (d *Duration) UnmarshalJSON(data []byte) error {
+	var s string
+	err := json.Unmarshal(data, &s)
+	if err != nil {
+		return err
+	}
+	dur, err := ParseDuration(s)
+	if err != nil {
+		return err
+	}
+	d = &dur
 	return nil
 }


### PR DESCRIPTION
@brian-brazil 
This PR adds methods to marshal and unmarshal JSON for model.Duration.

It addresses: https://github.com/prometheus/common/issues/227

After applying this diff I was able to successfully Unmarshal github.com/prometheus/alertmanager/config.Config