### PR TITLE
Clarify that this repo is considered internal to Prometheus

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 [![Build Status](https://travis-ci.org/prometheus/common.svg)](https://travis-ci.org/prometheus/common)
 
 This repository contains Go libraries that are shared across Prometheus
-components and libraries.
+components and libraries. They are considered internal to Prometheus, without
+any stability guarantees for external usage.
 
 * **config**: Common configuration structures
 * **expfmt**: Decoding and encoding for the exposition format


### PR DESCRIPTION
I have seen this statement multiple times in review comments. It might
help to have it here on the front page.

Signed-off-by: beorn7 <beorn@grafana.com>