### PR TITLE
Add support for more user-friendly duration input

### DIFF
--- a/model/time.go
+++ b/model/time.go
@@ -196,6 +196,8 @@ func ParseDuration(durationStr string) (Duration, error) {
 	}
 	var dur time.Duration
 
+	// Parse the match at pos `pos` in the regex and use `mult` to turn that
+	// into ms, then add that value to the total parsed duration.
 	m := func(pos int, mult time.Duration) {
 		if matches[pos] == "" {
 			return
@@ -205,13 +207,13 @@ func ParseDuration(durationStr string) (Duration, error) {
 		dur += d * mult
 	}
 
-	m(2, 1000*60*60*24*365)
-	m(4, 1000*60*60*24*7)
-	m(6, 1000*60*60*24)
-	m(8, 1000*60*60)
-	m(10, 1000*60)
-	m(12, 1000)
-	m(14, 1)
+	m(2, 1000*60*60*24*365) // y
+	m(4, 1000*60*60*24*7)   // w
+	m(6, 1000*60*60*24)     // d
+	m(8, 1000*60*60)        // h
+	m(10, 1000*60)          // m
+	m(12, 1000)             // s
+	m(14, 1)                // ms
 
 	return Duration(dur), nil
 }

--- a/model/time.go
+++ b/model/time.go
@@ -191,8 +191,7 @@ func ParseDuration(durationStr string) (Duration, error) {
 		return 0, nil
 	}
 	matches := durationRE.FindStringSubmatch(durationStr)
-	fmt.Printf("%v", len(matches))
-	if len(matches) != 15 {
+	if matches == nil {
 		return 0, fmt.Errorf("not a valid duration string: %q", durationStr)
 	}
 	var dur time.Duration

--- a/model/time.go
+++ b/model/time.go
@@ -181,7 +181,7 @@ func (d *Duration) Type() string {
 	return "duration"
 }
 
-var durationRE = regexp.MustCompile("^([0-9]+)(y|w|d|h|m|s|ms)$")
+var durationRE = regexp.MustCompile("^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$")
 
 // ParseDuration parses a string into a time.Duration, assuming that a year
 // always has 365d, a week always has 7d, and a day always has 24h.
@@ -191,67 +191,57 @@ func ParseDuration(durationStr string) (Duration, error) {
 		return 0, nil
 	}
 	matches := durationRE.FindStringSubmatch(durationStr)
-	if len(matches) != 3 {
+	fmt.Printf("%v", len(matches))
+	if len(matches) != 15 {
 		return 0, fmt.Errorf("not a valid duration string: %q", durationStr)
 	}
-	var (
-		n, _ = strconv.Atoi(matches[1])
-		dur  = time.Duration(n) * time.Millisecond
-	)
-	switch unit := matches[2]; unit {
-	case "y":
-		dur *= 1000 * 60 * 60 * 24 * 365
-	case "w":
-		dur *= 1000 * 60 * 60 * 24 * 7
-	case "d":
-		dur *= 1000 * 60 * 60 * 24
-	case "h":
-		dur *= 1000 * 60 * 60
-	case "m":
-		dur *= 1000 * 60
-	case "s":
-		dur *= 1000
-	case "ms":
-		// Value already correct
-	default:
-		return 0, fmt.Errorf("invalid time unit in duration string: %q", unit)
+	var dur time.Duration
+
+	m := func(pos int, mult time.Duration) {
+		if matches[pos] == "" {
+			return
+		}
+		n, _ := strconv.Atoi(matches[pos])
+		d := time.Duration(n) * time.Millisecond
+		dur += d * mult
 	}
+
+	m(2, 1000*60*60*24*365)
+	m(4, 1000*60*60*24*7)
+	m(6, 1000*60*60*24)
+	m(8, 1000*60*60)
+	m(10, 1000*60)
+	m(12, 1000)
+	m(14, 1)
+
 	return Duration(dur), nil
 }
 
 func (d Duration) String() string {
 	var (
-		ms   = int64(time.Duration(d) / time.Millisecond)
-		unit = "ms"
+		ms = int64(time.Duration(d) / time.Millisecond)
+		r  = ""
 	)
 	if ms == 0 {
 		return "0s"
 	}
-	factors := map[string]int64{
-		"y":  1000 * 60 * 60 * 24 * 365,
-		"w":  1000 * 60 * 60 * 24 * 7,
-		"d":  1000 * 60 * 60 * 24,
-		"h":  1000 * 60 * 60,
-		"m":  1000 * 60,
-		"s":  1000,
-		"ms": 1,
+
+	f := func(unit string, mult int64) {
+		if v := ms / mult; v > 0 {
+			r += fmt.Sprintf("%d%s", v, unit)
+			ms -= v * mult
+		}
 	}
 
-	switch int64(0) {
-	case ms % factors["y"]:
-		unit = "y"
-	case ms % factors["w"]:
-		unit = "w"
-	case ms % factors["d"]:
-		unit = "d"
-	case ms % factors["h"]:
-		unit = "h"
-	case ms % factors["m"]:
-		unit = "m"
-	case ms % factors["s"]:
-		unit = "s"
-	}
-	return fmt.Sprintf("%v%v", ms/factors[unit], unit)
+	f("y", 1000*60*60*24*365)
+	f("w", 1000*60*60*24*7)
+	f("d", 1000*60*60*24)
+	f("h", 1000*60*60)
+	f("m", 1000*60)
+	f("s", 1000)
+	f("ms", 1)
+
+	return r
 }
 
 // MarshalYAML implements the yaml.Marshaler interface.

--- a/model/time.go
+++ b/model/time.go
@@ -225,20 +225,26 @@ func (d Duration) String() string {
 		return "0s"
 	}
 
-	f := func(unit string, mult int64) {
+	f := func(unit string, mult int64, exact bool) {
+		if exact && ms%mult != 0 {
+			return
+		}
 		if v := ms / mult; v > 0 {
 			r += fmt.Sprintf("%d%s", v, unit)
 			ms -= v * mult
 		}
 	}
 
-	f("y", 1000*60*60*24*365)
-	f("w", 1000*60*60*24*7)
-	f("d", 1000*60*60*24)
-	f("h", 1000*60*60)
-	f("m", 1000*60)
-	f("s", 1000)
-	f("ms", 1)
+	// Only format years and weeks if the remainder is zero, as it is often
+	// easier to read 90d than 12w6d.
+	f("y", 1000*60*60*24*365, true)
+	f("w", 1000*60*60*24*7, true)
+
+	f("d", 1000*60*60*24, false)
+	f("h", 1000*60*60, false)
+	f("m", 1000*60, false)
+	f("s", 1000, false)
+	f("ms", 1, false)
 
 	return r
 }

--- a/model/time_test.go
+++ b/model/time_test.go
@@ -98,6 +98,10 @@ func TestParseDuration(t *testing.T) {
 			out:            0,
 			expectedString: "0s",
 		}, {
+			in:             "0w",
+			out:            0,
+			expectedString: "0s",
+		}, {
 			in:  "0s",
 			out: 0,
 		}, {
@@ -119,6 +123,10 @@ func TestParseDuration(t *testing.T) {
 			in:  "4d1h",
 			out: 4*24*time.Hour + time.Hour,
 		}, {
+			in:             "14d",
+			out:            14 * 24 * time.Hour,
+			expectedString: "2w",
+		}, {
 			in:  "3w",
 			out: 3 * 7 * 24 * time.Hour,
 		}, {
@@ -127,9 +135,6 @@ func TestParseDuration(t *testing.T) {
 		}, {
 			in:  "10y",
 			out: 10 * 365 * 24 * time.Hour,
-		}, {
-			in:  "10ms",
-			out: 10 * time.Millisecond,
 		},
 	}
 
@@ -148,6 +153,23 @@ func TestParseDuration(t *testing.T) {
 		if d.String() != expectedString {
 			t.Errorf("Expected duration string %q but got %q", c.in, d.String())
 		}
+	}
+}
+
+func TestParseBadDuration(t *testing.T) {
+	var cases = []string{
+		"1",
+		"1y1m1d",
+		"-1w",
+		"1.5d",
+	}
+
+	for _, c := range cases {
+		_, err := ParseDuration(c)
+		if err == nil {
+			t.Errorf("Expected error on input %s", c)
+		}
+
 	}
 }
 

--- a/model/time_test.go
+++ b/model/time_test.go
@@ -116,11 +116,20 @@ func TestParseDuration(t *testing.T) {
 			in:  "4d",
 			out: 4 * 24 * time.Hour,
 		}, {
+			in:  "4d1h",
+			out: 4*24*time.Hour + time.Hour,
+		}, {
 			in:  "3w",
 			out: 3 * 7 * 24 * time.Hour,
 		}, {
+			in:  "3w2d1h",
+			out: 3*7*24*time.Hour + 2*24*time.Hour + time.Hour,
+		}, {
 			in:  "10y",
 			out: 10 * 365 * 24 * time.Hour,
+		}, {
+			in:  "10ms",
+			out: 10 * time.Millisecond,
 		},
 	}
 

--- a/model/time_test.go
+++ b/model/time_test.go
@@ -130,8 +130,9 @@ func TestParseDuration(t *testing.T) {
 			in:  "3w",
 			out: 3 * 7 * 24 * time.Hour,
 		}, {
-			in:  "3w2d1h",
-			out: 3*7*24*time.Hour + 2*24*time.Hour + time.Hour,
+			in:             "3w2d1h",
+			out:            3*7*24*time.Hour + 2*24*time.Hour + time.Hour,
+			expectedString: "23d1h",
 		}, {
 			in:  "10y",
 			out: 10 * 365 * 24 * time.Hour,


### PR DESCRIPTION
With this pull request, it is possible to write:

6d23h

instead of

167h

Which is a lot more easy to read.

** This is a breaking change, unless we remove the re-marshalling for now. **

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>