### PR TITLE
Fix an issue with Secret.MarshalYAML

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -23,10 +23,7 @@ type Secret string
 
 // MarshalYAML implements the yaml.Marshaler interface for Secrets.
 func (s Secret) MarshalYAML() (interface{}, error) {
-	if s != "" {
-		return "<secret>", nil
-	}
-	return nil, nil
+	return s, nil
 }
 
 //UnmarshalYAML implements the yaml.Unmarshaler interface for Secrets.

--- a/config/config.go
+++ b/config/config.go
@@ -23,7 +23,7 @@ type Secret string
 
 // MarshalYAML implements the yaml.Marshaler interface for Secrets.
 func (s Secret) MarshalYAML() (interface{}, error) {
-	return s, nil
+	return string(s), nil
 }
 
 //UnmarshalYAML implements the yaml.Unmarshaler interface for Secrets.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,22 @@
+package config
+
+import (
+	"bytes"
+	"testing"
+
+	"gopkg.in/yaml.v2"
+)
+
+func TestSecretMarshalYAML(t *testing.T) {
+	var newSecret = Secret("test-secret")
+	var expectedResult = []byte("test-secret\n")
+
+	result, err := yaml.Marshal(newSecret)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(result, expectedResult) {
+		t.Errorf("The expected value (%#q) differs from the obtained value (%#q)", expectedResult, result)
+	}
+}


### PR DESCRIPTION
Hello, I've come across an issue with yaml encoding due to this library.

### Context

I am writing an operator in Go, which generates `alertmanager` config file. To achieve this I make use of `github.com/prometheus/alertmanager/config.{Load,String}` methods, which do exactly what I need decode and encode alertmanager config from and to yaml format.
Decoding works fine but when I encode the config back I got weird values for all my secrets.

before

```yaml
    receivers:
    - name: heartbeat
      webhook_configs:
      - send_resolved: false
        http_config:
          basic_auth:
            username: ""
            password: <secret>            <---- this is not my value
        url: https://some-api
        max_alerts: 0
```

alertmanager make used of `github.com/prometheus/common/config.Secret` for all its secret value. But for some reason I ignore the `MarhsalYAML` function always returns `<secret>` which just discard the value which was stored there. By actually return the stored value, I can now generate the correct alertmanager config.

after

```yaml
    receivers:
    - name: heartbeat
      webhook_configs:
      - send_resolved: false
        http_config:
          basic_auth:
            username: ""
            password: my-secret-password   <---- this is my value
        url: https://some-api
        max_alerts: 0
```