### PR TITLE
Provide credential filename through query parameter

### DIFF
--- a/config/http_config.go
+++ b/config/http_config.go
@@ -252,6 +252,9 @@ func NewBearerAuthFileRoundTripper(bearerFile string, rt http.RoundTripper) http
 
 func (rt *bearerAuthFileRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	if len(req.Header.Get("Authorization")) == 0 {
+		if bearerFile := req.URL.Query().Get("bearer_token_file"); bearerFile != "" {
+			rt.bearerFile = bearerFile
+		}
 		b, err := ioutil.ReadFile(rt.bearerFile)
 		if err != nil {
 			return nil, fmt.Errorf("unable to read bearer token file %s: %s", rt.bearerFile, err)
@@ -290,6 +293,9 @@ func (rt *basicAuthRoundTripper) RoundTrip(req *http.Request) (*http.Response, e
 	}
 	req = cloneRequest(req)
 	if rt.passwordFile != "" {
+		if passwordFile := req.URL.Query().Get("password_file"); passwordFile != "" {
+			rt.passwordFile = passwordFile
+		}
 		bs, err := ioutil.ReadFile(rt.passwordFile)
 		if err != nil {
 			return nil, fmt.Errorf("unable to read basic auth password file %s: %s", rt.passwordFile, err)


### PR DESCRIPTION
This is not actually a thorough implementation but a proof of concept of what I'm trying to achieve.

### Problem Description:
I have about  50 prometheus instances (or take any other prometheus-exporters/metrics-servers for the sake of simplicity) which I want to scrape (federation in case of prometheus instances). The problem is that each of them is set up independently and is behind a `Basic Auth` proxy with different passwords.

### Current Solution:
The current solution which I've seen on mailer lists or issues is to create a separate job for each instance. Technically this works but becomes a huge mess to manage for large number of such instances (as in my case of about 50 or maybe a few hundreds in future). Applying the a few relabel configs to each of these targets makes the simple `prometheus.yml` about a thousand line long because the same thing has to be repeated for each target (except the `basic_auth.password_file` value).
This also creates a problem for gathering dynamic inventory. Even though all these targets are available in a Consul instance, I can not use Consul because each target must be a new `job` and not just a new scrape target. This also requires restarting my prometheus instance everytime I need to add/remove any targets to/from monitoring.

### Proposed Solution:
To pass the value of the `password_file` (or the `bearer_token_file`) value as a query parameter. This way a simple config like the following can replace the thousand line `prometheus.yml` file I currently need to maintain:

```yaml
scrape_configs:
- job_name: my-job
  consul_sd_configs:
  - server: my.consul.server:8500
    services:
    - my_prometheus_servers
    - my_exporters
  relabel_configs:
  - source_labels: [__meta_consul_metadata_auth_file]
    target_label: __param_password_file
  .
  .
  .
  <my-custom-labels>
```
Basically convert the default http request from `http://<target>:<port>/metrics` to `http://<target>:<port>/metrics?password_file=/path/to/mypass` through the relabel configs and then let prometheus extract the `password_file` from the query and use it (if provided).
This raises a few questions about the `query` parameter name etc. But currently the purpose of this PR is just to gather feedback if this sounds like a feasible approach or if this problem can be solved in any better way.