### PR TITLE
AddingPowerSupport_CI/Testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
+arch:
+  - amd64
+  - ppc64le
 language: go
 # Supported Go versions are synced with github.com/prometheus/client_golang.
 go:
-  - 1.9.x
-  - 1.10.x
-  - 1.11.x
-  - 1.12.x
   - 1.13.x
   - 1.14.x
   - 1.15.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,24 @@ arch:
 language: go
 # Supported Go versions are synced with github.com/prometheus/client_golang.
 go:
+  - 1.9.x
+  - 1.10.x
+  - 1.11.x
+  - 1.12.x
   - 1.13.x
   - 1.14.x
   - 1.15.x
+jobs:
+ exclude:
+  - go: 1.9.x
+    arch: ppc64le
+  - go: 1.10.x
+    arch: ppc64le
+  - go: 1.11.x
+    arch: ppc64le
+  - go: 1.12.x
+    arch: ppc64le
+
 
 script:
   - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ go:
 jobs:
  exclude:
   - go: 1.9.x
+    arch: amd64
+  - go: 1.10.x
+    arch: amd64
+  - go: 1.9.x
     arch: ppc64le
   - go: 1.10.x
     arch: ppc64le


### PR DESCRIPTION
Adding Power support & updating go versions to >=1.13 as lower versions are not supported.,

Adding power support ppc64le with Continues Integration/testing so that code remains architecture independent.

This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3.

The build is successful on both arch: amd64/ppc64le, please find the Travis Link below.
https://travis-ci.com/github/santosh653/common

Please let me know if you need any further details.

Thanks You !!