### PR TITLE
Support authorization_credentials

### DIFF
--- a/config/http_config.go
+++ b/config/http_config.go
@@ -52,6 +52,21 @@ func (a *BasicAuth) SetDirectory(dir string) {
 	a.PasswordFile = JoinDir(dir, a.PasswordFile)
 }
 
+// Authorization contains HTTP authorization credentials.
+type Authorization struct {
+	Type            string `yaml:"type,omitempty"`
+	Credentials     Secret `yaml:"credentials,omitempty"`
+	CredentialsFile string `yaml:"credentials_file,omitempty"`
+}
+
+// SetDirectory joins any relative file paths with dir.
+func (a *Authorization) SetDirectory(dir string) {
+	if a == nil {
+		return
+	}
+	a.CredentialsFile = JoinDir(dir, a.CredentialsFile)
+}
+
 // URL is a custom URL type that allows validation at configuration load time.
 type URL struct {
 	*url.URL
@@ -84,14 +99,21 @@ func (u URL) MarshalYAML() (interface{}, error) {
 type HTTPClientConfig struct {
 	// The HTTP basic authentication credentials for the targets.
 	BasicAuth *BasicAuth `yaml:"basic_auth,omitempty"`
-	// The bearer token for the targets.
+	// The HTTP authorization credentials for the targets.
+	Authorization *Authorization `yaml:"authorization,omitempty"`
+	// The bearer token for the targets. Deprecated in favour of
+	// Authorization.Credentials.
 	BearerToken Secret `yaml:"bearer_token,omitempty"`
-	// The bearer token file for the targets.
+	// The bearer token file for the targets. Deprecated in favour of
+	// Authorization.CredentialsFile.
 	BearerTokenFile string `yaml:"bearer_token_file,omitempty"`
 	// HTTP proxy server to use to connect to the targets.
 	ProxyURL URL `yaml:"proxy_url,omitempty"`
 	// TLSConfig to use to connect to the targets.
 	TLSConfig TLSConfig `yaml:"tls_config,omitempty"`
+	// Used to make sure that the configuration is valid and that BearerToken to
+	// Authorization.Credentials change has been handled.
+	valid bool
 }
 
 // SetDirectory joins any relative file paths with dir.
@@ -101,12 +123,14 @@ func (c *HTTPClientConfig) SetDirectory(dir string) {
 	}
 	c.TLSConfig.SetDirectory(dir)
 	c.BasicAuth.SetDirectory(dir)
+	c.Authorization.SetDirectory(dir)
 	c.BearerTokenFile = JoinDir(dir, c.BearerTokenFile)
 }
 
 // Validate validates the HTTPClientConfig to check only one of BearerToken,
 // BasicAuth and BearerTokenFile is configured.
 func (c *HTTPClientConfig) Validate() error {
+	// Backwards compatibility with the bearer_token field.
 	if len(c.BearerToken) > 0 && len(c.BearerTokenFile) > 0 {
 		return fmt.Errorf("at most one of bearer_token & bearer_token_file must be configured")
 	}
@@ -116,6 +140,37 @@ func (c *HTTPClientConfig) Validate() error {
 	if c.BasicAuth != nil && (string(c.BasicAuth.Password) != "" && c.BasicAuth.PasswordFile != "") {
 		return fmt.Errorf("at most one of basic_auth password & password_file must be configured")
 	}
+	if c.Authorization != nil {
+		if len(c.BearerToken) > 0 || len(c.BearerTokenFile) > 0 {
+			return fmt.Errorf("authorization is not compatible with bearer_token & bearer_token_file")
+		}
+		if string(c.Authorization.Credentials) != "" && c.Authorization.CredentialsFile != "" {
+			return fmt.Errorf("at most one of authorization credentials & credentials_file must be configured")
+		}
+		c.Authorization.Type = strings.TrimSpace(c.Authorization.Type)
+		if len(c.Authorization.Type) == 0 {
+			c.Authorization.Type = "Bearer"
+		}
+		if strings.ToLower(c.Authorization.Type) == "basic" {
+			return fmt.Errorf(`authorization type cannot be set to "basic", use "basic_auth" instead`)
+		}
+		if c.BasicAuth != nil {
+			return fmt.Errorf("at most one of basic_auth & authorization must be configured")
+		}
+	} else {
+		if len(c.BearerToken) > 0 {
+			c.Authorization = &Authorization{Credentials: c.BearerToken}
+			c.Authorization.Type = "Bearer"
+			c.BearerToken = ""
+		}
+		if len(c.BearerTokenFile) > 0 {
+			c.Authorization = &Authorization{CredentialsFile: c.BearerTokenFile}
+			c.Authorization.Type = "Bearer"
+			c.BearerTokenFile = ""
+		}
+	}
+
+	c.valid = true
 	return nil
 }
 
@@ -152,6 +207,12 @@ func NewClientFromConfig(cfg HTTPClientConfig, name string, disableKeepAlives, e
 // NewRoundTripperFromConfig returns a new HTTP RoundTripper configured for the
 // given config.HTTPClientConfig. The name is used as go-conntrack metric label.
 func NewRoundTripperFromConfig(cfg HTTPClientConfig, name string, disableKeepAlives, enableHTTP2 bool) (http.RoundTripper, error) {
+	// Make sure that the configuration is valid.
+	if !cfg.valid {
+		if err := cfg.Validate(); err != nil {
+			return nil, err
+		}
+	}
 	newRT := func(tlsConfig *tls.Config) (http.RoundTripper, error) {
 		// The only timeout we care about is the configured scrape timeout.
 		// It is applied on request. So we leave out any timings here.
@@ -186,12 +247,12 @@ func NewRoundTripperFromConfig(cfg HTTPClientConfig, name string, disableKeepAli
 			}
 		}
 
-		// If a bearer token is provided, create a round tripper that will set the
+		// If a authorization_credentials is provided, create a round tripper that will set the
 		// Authorization header correctly on each request.
-		if len(cfg.BearerToken) > 0 {
-			rt = NewBearerAuthRoundTripper(cfg.BearerToken, rt)
-		} else if len(cfg.BearerTokenFile) > 0 {
-			rt = NewBearerAuthFileRoundTripper(cfg.BearerTokenFile, rt)
+		if cfg.Authorization != nil && len(cfg.Authorization.Credentials) > 0 {
+			rt = NewAuthorizationCredentialsRoundTripper(cfg.Authorization.Type, cfg.Authorization.Credentials, rt)
+		} else if cfg.Authorization != nil && len(cfg.Authorization.CredentialsFile) > 0 {
+			rt = NewAuthorizationCredentialsFileRoundTripper(cfg.Authorization.Type, cfg.Authorization.CredentialsFile, rt)
 		}
 
 		if cfg.BasicAuth != nil {
@@ -214,58 +275,61 @@ func NewRoundTripperFromConfig(cfg HTTPClientConfig, name string, disableKeepAli
 	return newTLSRoundTripper(tlsConfig, cfg.TLSConfig.CAFile, newRT)
 }
 
-type bearerAuthRoundTripper struct {
-	bearerToken Secret
-	rt          http.RoundTripper
+type authorizationCredentialsRoundTripper struct {
+	authType        string
+	authCredentials Secret
+	rt              http.RoundTripper
 }
 
-// NewBearerAuthRoundTripper adds the provided bearer token to a request unless the authorization
-// header has already been set.
-func NewBearerAuthRoundTripper(token Secret, rt http.RoundTripper) http.RoundTripper {
-	return &bearerAuthRoundTripper{token, rt}
+// NewAuthorizationCredentialsRoundTripper adds the provided credentials to a
+// request unless the authorization header has already been set.
+func NewAuthorizationCredentialsRoundTripper(authType string, authCredentials Secret, rt http.RoundTripper) http.RoundTripper {
+	return &authorizationCredentialsRoundTripper{authType, authCredentials, rt}
 }
 
-func (rt *bearerAuthRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+func (rt *authorizationCredentialsRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	if len(req.Header.Get("Authorization")) == 0 {
 		req = cloneRequest(req)
-		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", string(rt.bearerToken)))
+		req.Header.Set("Authorization", fmt.Sprintf("%s %s", rt.authType, string(rt.authCredentials)))
 	}
 	return rt.rt.RoundTrip(req)
 }
 
-func (rt *bearerAuthRoundTripper) CloseIdleConnections() {
+func (rt *authorizationCredentialsRoundTripper) CloseIdleConnections() {
 	if ci, ok := rt.rt.(closeIdler); ok {
 		ci.CloseIdleConnections()
 	}
 }
 
-type bearerAuthFileRoundTripper struct {
-	bearerFile string
-	rt         http.RoundTripper
+type authorizationCredentialsFileRoundTripper struct {
+	authType            string
+	authCredentialsFile string
+	rt                  http.RoundTripper
 }
 
-// NewBearerAuthFileRoundTripper adds the bearer token read from the provided file to a request unless
-// the authorization header has already been set. This file is read for every request.
-func NewBearerAuthFileRoundTripper(bearerFile string, rt http.RoundTripper) http.RoundTripper {
-	return &bearerAuthFileRoundTripper{bearerFile, rt}
+// NewAuthorizationCredentialsFileRoundTripper adds the authorization
+// credentials read from the provided file to a request unless the authorization
+// header has already been set. This file is read for every request.
+func NewAuthorizationCredentialsFileRoundTripper(authType, authCredentialsFile string, rt http.RoundTripper) http.RoundTripper {
+	return &authorizationCredentialsFileRoundTripper{authType, authCredentialsFile, rt}
 }
 
-func (rt *bearerAuthFileRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+func (rt *authorizationCredentialsFileRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	if len(req.Header.Get("Authorization")) == 0 {
-		b, err := ioutil.ReadFile(rt.bearerFile)
+		b, err := ioutil.ReadFile(rt.authCredentialsFile)
 		if err != nil {
-			return nil, fmt.Errorf("unable to read bearer token file %s: %s", rt.bearerFile, err)
+			return nil, fmt.Errorf("unable to read authorization credentials file %s: %s", rt.authCredentialsFile, err)
 		}
-		bearerToken := strings.TrimSpace(string(b))
+		authCredentials := strings.TrimSpace(string(b))
 
 		req = cloneRequest(req)
-		req.Header.Set("Authorization", "Bearer "+bearerToken)
+		req.Header.Set("Authorization", fmt.Sprintf("%s %s", rt.authType, authCredentials))
 	}
 
 	return rt.rt.RoundTrip(req)
 }
 
-func (rt *bearerAuthFileRoundTripper) CloseIdleConnections() {
+func (rt *authorizationCredentialsFileRoundTripper) CloseIdleConnections() {
 	if ci, ok := rt.rt.(closeIdler); ok {
 		ci.CloseIdleConnections()
 	}

--- a/config/testdata/http.conf.auth-creds-and-file-set.too-much.bad.yaml
+++ b/config/testdata/http.conf.auth-creds-and-file-set.too-much.bad.yaml
@@ -1,0 +1,3 @@
+authorization:
+  credentials: bearertoken
+  credentials_file: key.txt

--- a/config/testdata/http.conf.auth-creds-no-basic.bad.yaml
+++ b/config/testdata/http.conf.auth-creds-no-basic.bad.yaml
@@ -1,0 +1,2 @@
+authorization:
+  type: Basic

--- a/config/testdata/http.conf.basic-auth-and-auth-creds.too-much.bad.yaml
+++ b/config/testdata/http.conf.basic-auth-and-auth-creds.too-much.bad.yaml
@@ -1,0 +1,5 @@
+basic_auth:
+  username: user
+  password: foo
+authorization:
+  credentials: foo

--- a/config/testdata/http.conf.mix-bearer-and-creds.bad.yaml
+++ b/config/testdata/http.conf.mix-bearer-and-creds.bad.yaml
@@ -1,0 +1,3 @@
+authorization:
+  type: APIKEY
+bearer_token: foo


### PR DESCRIPTION
This backward-compatible patch enables authorization header type to be
set.

For consistency, bearer_token is renamed to authorization_credentials
and a new authorization_type is introduced.

The terminology is taken from
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization


refs:
https://github.com/prometheus/common/issues/271
https://github.com/prometheus/prometheus/issues/5107

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>