### PR TITLE
Remove private field in http config

### DIFF
--- a/config/http_config_test.go
+++ b/config/http_config_test.go
@@ -306,6 +306,10 @@ func TestNewClientFromConfig(t *testing.T) {
 		}
 		defer testServer.Close()
 
+		err = validConfig.clientConfig.Validate()
+		if err != nil {
+			t.Fatal(err.Error())
+		}
 		client, err := NewClientFromConfig(validConfig.clientConfig, "test", false, true)
 		if err != nil {
 			t.Errorf("Can't create a client from this config: %+v", validConfig.clientConfig)


### PR DESCRIPTION
The private field in http config is causing issue while implementing in
Prometheus. It was there to be nice with importers who would import the
code and not call Validate(). I still want to be nice so I have added a
workaround for those users.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>