### PR TITLE
Use http.Handler, not http.HandlerFunc.

### DIFF
--- a/route/route.go
+++ b/route/route.go
@@ -41,7 +41,7 @@ func WithParam(ctx context.Context, p, v string) context.Context {
 type Router struct {
 	rtr    *httprouter.Router
 	prefix string
-	instrh func(handlerName string, handler http.Handler) http.Handler
+	instrh func(handlerName string, handler http.Handler) http.HandlerFunc
 }
 
 // New returns a new Router.
@@ -52,10 +52,10 @@ func New() *Router {
 }
 
 // WithInstrumentation returns a router with instrumentation support.
-func (r *Router) WithInstrumentation(instrh func(handlerName string, handler http.Handler) http.Handler) *Router {
+func (r *Router) WithInstrumentation(instrh func(handlerName string, handler http.Handler) http.HandlerFunc) *Router {
 	if r.instrh != nil {
 		newInstrh := instrh
-		instrh = func(handlerName string, handler http.Handler) http.Handler {
+		instrh = func(handlerName string, handler http.Handler) http.HandlerFunc {
 			return newInstrh(handlerName, r.instrh(handlerName, handler))
 		}
 	}

--- a/route/route_test.go
+++ b/route/route_test.go
@@ -120,9 +120,9 @@ func TestInstrumentation(t *testing.T) {
 			router: New(),
 			want:   "",
 		}, {
-			router: New().WithInstrumentation(func(handlerName string, handler http.Handler) http.Handler {
+			router: New().WithInstrumentation(func(handlerName string, handler http.Handler) http.HandlerFunc {
 				got = handlerName
-				return handler
+				return handler.ServeHTTP
 			}),
 			want: "/foo",
 		},
@@ -154,19 +154,19 @@ func TestInstrumentations(t *testing.T) {
 		}, {
 			router: New().
 				WithInstrumentation(
-					func(handlerName string, handler http.Handler) http.Handler {
+					func(handlerName string, handler http.Handler) http.HandlerFunc {
 						got = append(got, "1"+handlerName)
-						return handler
+						return handler.ServeHTTP
 					}).
 				WithInstrumentation(
-					func(handlerName string, handler http.Handler) http.Handler {
+					func(handlerName string, handler http.Handler) http.HandlerFunc {
 						got = append(got, "2"+handlerName)
-						return handler
+						return handler.ServeHTTP
 					}).
 				WithInstrumentation(
-					func(handlerName string, handler http.Handler) http.Handler {
+					func(handlerName string, handler http.Handler) http.HandlerFunc {
 						got = append(got, "3"+handlerName)
-						return handler
+						return handler.ServeHTTP
 					}),
 			want: []string{"1/foo", "2/foo", "3/foo"},
 		},

--- a/route/route_test.go
+++ b/route/route_test.go
@@ -41,13 +41,13 @@ func TestRedirect(t *testing.T) {
 
 func TestContext(t *testing.T) {
 	router := New()
-	router.Get("/test/:foo/", func(w http.ResponseWriter, r *http.Request) {
+	router.Get("/test/:foo/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		want := "bar"
 		got := Param(r.Context(), "foo")
 		if want != got {
 			t.Fatalf("Unexpected context value: want %q, got %q", want, got)
 		}
-	})
+	}))
 
 	r, err := http.NewRequest("GET", "http://localhost:9090/test/bar/", nil)
 	if err != nil {
@@ -58,7 +58,7 @@ func TestContext(t *testing.T) {
 
 func TestContextWithValue(t *testing.T) {
 	router := New()
-	router.Get("/test/:foo/", func(w http.ResponseWriter, r *http.Request) {
+	router.Get("/test/:foo/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		want := "bar"
 		got := Param(r.Context(), "foo")
 		if want != got {
@@ -74,7 +74,7 @@ func TestContextWithValue(t *testing.T) {
 		if want != got {
 			t.Fatalf("Unexpected context value: want %q, got %q", want, got)
 		}
-	})
+	}))
 
 	r, err := http.NewRequest("GET", "http://localhost:9090/test/bar/", nil)
 	if err != nil {
@@ -95,13 +95,13 @@ func TestContextWithValue(t *testing.T) {
 
 func TestContextWithoutValue(t *testing.T) {
 	router := New()
-	router.Get("/test", func(w http.ResponseWriter, r *http.Request) {
+	router.Get("/test", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		want := ""
 		got := Param(r.Context(), "foo")
 		if want != got {
 			t.Fatalf("Unexpected context value: want %q, got %q", want, got)
 		}
-	})
+	}))
 
 	r, err := http.NewRequest("GET", "http://localhost:9090/test", nil)
 	if err != nil {
@@ -120,7 +120,7 @@ func TestInstrumentation(t *testing.T) {
 			router: New(),
 			want:   "",
 		}, {
-			router: New().WithInstrumentation(func(handlerName string, handler http.HandlerFunc) http.HandlerFunc {
+			router: New().WithInstrumentation(func(handlerName string, handler http.Handler) http.Handler {
 				got = handlerName
 				return handler
 			}),
@@ -129,7 +129,7 @@ func TestInstrumentation(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		c.router.Get("/foo", func(w http.ResponseWriter, r *http.Request) {})
+		c.router.Get("/foo", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 
 		r, err := http.NewRequest("GET", "http://localhost:9090/foo", nil)
 		if err != nil {
@@ -154,17 +154,17 @@ func TestInstrumentations(t *testing.T) {
 		}, {
 			router: New().
 				WithInstrumentation(
-					func(handlerName string, handler http.HandlerFunc) http.HandlerFunc {
+					func(handlerName string, handler http.Handler) http.Handler {
 						got = append(got, "1"+handlerName)
 						return handler
 					}).
 				WithInstrumentation(
-					func(handlerName string, handler http.HandlerFunc) http.HandlerFunc {
+					func(handlerName string, handler http.Handler) http.Handler {
 						got = append(got, "2"+handlerName)
 						return handler
 					}).
 				WithInstrumentation(
-					func(handlerName string, handler http.HandlerFunc) http.HandlerFunc {
+					func(handlerName string, handler http.Handler) http.Handler {
 						got = append(got, "3"+handlerName)
 						return handler
 					}),
@@ -173,7 +173,7 @@ func TestInstrumentations(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		c.router.Get("/foo", func(w http.ResponseWriter, r *http.Request) {})
+		c.router.Get("/foo", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 
 		r, err := http.NewRequest("GET", "http://localhost:9090/foo", nil)
 		if err != nil {


### PR DESCRIPTION
This is not a backwards incompatible change, even if all `http.HandlerFunc`s are `http.Handler`s - go will implictly convert a function of the right signature to a `HandlerFunc`, but you need to explicitly convert it to a `Handler` via a `HandlerFunc`.

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>