### PR TITLE
http: Add the ability to not follow redirects

### DIFF
--- a/config/http_config.go
+++ b/config/http_config.go
@@ -116,7 +116,7 @@ type HTTPClientConfig struct {
 	ProxyURL URL `yaml:"proxy_url,omitempty"`
 	// TLSConfig to use to connect to the targets.
 	TLSConfig TLSConfig `yaml:"tls_config,omitempty"`
-	// FollowRedirects specifies wheter the client should follow HTTP 3xx redirects.
+	// FollowRedirects specifies whether the client should follow HTTP 3xx redirects.
 	// The omitempty flag is not set, because it would be hidden from the
 	// marshalled configuration when set to false.
 	FollowRedirects bool `yaml:"follow_redirects"`

--- a/config/http_config.go
+++ b/config/http_config.go
@@ -33,6 +33,11 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+// DefaultHTTPClientConfig is the default HTTP client configuration.
+var DefaultHTTPClientConfig = HTTPClientConfig{
+	FollowRedirects: true,
+}
+
 type closeIdler interface {
 	CloseIdleConnections()
 }
@@ -111,7 +116,7 @@ type HTTPClientConfig struct {
 	ProxyURL URL `yaml:"proxy_url,omitempty"`
 	// TLSConfig to use to connect to the targets.
 	TLSConfig TLSConfig `yaml:"tls_config,omitempty"`
-	// FollowRedirects specifies wheter the client should follow the HTTP 3xx redirects.
+	// FollowRedirects specifies wheter the client should follow HTTP 3xx redirects.
 	// The omitempty flag is not set, because it would be hidden from the
 	// marshalled configuration when set to false.
 	FollowRedirects bool `yaml:"follow_redirects"`
@@ -176,9 +181,7 @@ func (c *HTTPClientConfig) Validate() error {
 // UnmarshalYAML implements the yaml.Unmarshaler interface
 func (c *HTTPClientConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	type plain HTTPClientConfig
-	*c = HTTPClientConfig{
-		FollowRedirects: true,
-	}
+	*c = DefaultHTTPClientConfig
 	if err := unmarshal((*plain)(c)); err != nil {
 		return err
 	}

--- a/config/http_config_test.go
+++ b/config/http_config_test.go
@@ -296,6 +296,44 @@ func TestNewClientFromConfig(t *testing.T) {
 					fmt.Fprint(w, ExpectedMessage)
 				}
 			},
+		}, {
+			clientConfig: HTTPClientConfig{
+				FollowRedirects: true,
+				TLSConfig: TLSConfig{
+					CAFile:             TLSCAChainPath,
+					CertFile:           ClientCertificatePath,
+					KeyFile:            ClientKeyNoPassPath,
+					ServerName:         "",
+					InsecureSkipVerify: false},
+			},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/redirected":
+					fmt.Fprintf(w, ExpectedMessage)
+				default:
+					http.Redirect(w, r, "/redirected", http.StatusFound)
+				}
+			},
+		}, {
+			clientConfig: HTTPClientConfig{
+				FollowRedirects: false,
+				TLSConfig: TLSConfig{
+					CAFile:             TLSCAChainPath,
+					CertFile:           ClientCertificatePath,
+					KeyFile:            ClientKeyNoPassPath,
+					ServerName:         "",
+					InsecureSkipVerify: false},
+			},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/redirected":
+					fmt.Fprint(w, "The redirection was followed.")
+				default:
+					w.Header()["Content-Type"] = nil
+					http.Redirect(w, r, "/redirected", http.StatusFound)
+					fmt.Fprint(w, ExpectedMessage)
+				}
+			},
 		},
 	}
 
@@ -317,7 +355,7 @@ func TestNewClientFromConfig(t *testing.T) {
 		}
 		response, err := client.Get(testServer.URL)
 		if err != nil {
-			t.Errorf("Can't connect to the test server using this config: %+v", validConfig.clientConfig)
+			t.Errorf("Can't connect to the test server using this config: %+v %v", validConfig.clientConfig, err)
 			continue
 		}
 
@@ -929,6 +967,16 @@ func TestHideHTTPClientConfigSecrets(t *testing.T) {
 	s := c.String()
 	if strings.Contains(s, "mysecret") {
 		t.Fatal("http client config's String method reveals authentication credentials.")
+	}
+}
+
+func TestDefaultFollowRedirect(t *testing.T) {
+	cfg, _, err := LoadHTTPConfigFile("testdata/http.conf.good.yml")
+	if err != nil {
+		t.Errorf("Error loading HTTP client config: %v", err)
+	}
+	if !cfg.FollowRedirects {
+		t.Errorf("follow_redirects should be true")
 	}
 }
 

--- a/config/http_config_test.go
+++ b/config/http_config_test.go
@@ -357,7 +357,7 @@ func TestNewClientFromConfig(t *testing.T) {
 		}
 		response, err := client.Get(testServer.URL)
 		if err != nil {
-			t.Errorf("Can't connect to the test server using this config: %+v %v", validConfig.clientConfig, err)
+			t.Errorf("Can't connect to the test server using this config: %+v: %v", validConfig.clientConfig, err)
 			continue
 		}
 

--- a/config/http_config_test.go
+++ b/config/http_config_test.go
@@ -311,7 +311,9 @@ func TestNewClientFromConfig(t *testing.T) {
 				case "/redirected":
 					fmt.Fprintf(w, ExpectedMessage)
 				default:
-					http.Redirect(w, r, "/redirected", http.StatusFound)
+					w.Header().Set("Location", "/redirected")
+					w.WriteHeader(http.StatusFound)
+					fmt.Fprintf(w, "It should follow the redirect.")
 				}
 			},
 		}, {
@@ -329,9 +331,9 @@ func TestNewClientFromConfig(t *testing.T) {
 				case "/redirected":
 					fmt.Fprint(w, "The redirection was followed.")
 				default:
-					w.Header()["Content-Type"] = nil
-					http.Redirect(w, r, "/redirected", http.StatusFound)
-					fmt.Fprint(w, ExpectedMessage)
+					w.Header().Set("Location", "/redirected")
+					w.WriteHeader(http.StatusFound)
+					fmt.Fprintf(w, ExpectedMessage)
 				}
 			},
 		},


### PR DESCRIPTION
Currently, when we unmarshal, we get the default value, which is to
follow redirects.


Related to https://github.com/prometheus/prometheus/issues/5108

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>