### PR TITLE
Generate hashCAFile with SHA256

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,20 +44,6 @@ workflows:
     jobs:
     # Supported Go versions are synced with github.com/prometheus/client_golang.
     - test:
-        name: go-1-9
-        go_version: "1.9"
-        use_gomod_cache: false
-    - test:
-        name: go-1-10
-        go_version: "1.10"
-        use_gomod_cache: false
-    - test:
-        name: go-1-11
-        go_version: "1.11"
-    - test:
-        name: go-1-12
-        go_version: "1.12"
-    - test:
         name: go-1-13
         go_version: "1.13"
     - test:

--- a/config/http_config.go
+++ b/config/http_config.go
@@ -17,7 +17,7 @@ package config
 
 import (
 	"bytes"
-	"crypto/md5"
+	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -533,7 +533,7 @@ func (t *tlsRoundTripper) getCAWithHash() ([]byte, []byte, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	h := md5.Sum(b)
+	h := sha256.Sum256(b)
 	return b, h[:], nil
 
 }


### PR DESCRIPTION
I've been tasked with checking FIPS compliance of the GitLab codebase. One attribute of FIPS compliance is that MD5 hashes are frowned upon.

It's going to be much easier to switch to SHA256 for this specific use than to explain in detail why MD5 is fine :sweat_smile: so I'd love to get this merged.