### PR TITLE
Fix #8526 (https://github.com/prometheus/prometheus/issues/8526)

### DIFF
--- a/model/time.go
+++ b/model/time.go
@@ -211,6 +211,12 @@ func ParseDuration(durationStr string) (Duration, error) {
 		dur += d * mult
 	}
 
+	// Check if year range exceed 290 years
+	year, _ := strconv.Atoi(matches[2])
+	if year > 290 {
+		return 0, fmt.Errorf("Time range exceeds 290 years limit: %d", year)
+	}
+
 	m(2, 1000*60*60*24*365) // y
 	m(4, 1000*60*60*24*7)   // w
 	m(6, 1000*60*60*24)     // d

--- a/model/time.go
+++ b/model/time.go
@@ -210,7 +210,7 @@ func ParseDuration(durationStr string) (Duration, error) {
 		}
 		n, _ := strconv.Atoi(matches[pos])
 
-		// Check if the provider duration overflows time.Duration (> ~ 290years).
+		// Check if the provided duration overflows time.Duration (> ~ 290years).
 		if n > int((1<<63-1)/mult/time.Millisecond) {
 			overflowErr = errors.New("duration out of range")
 		}

--- a/model/time.go
+++ b/model/time.go
@@ -210,7 +210,7 @@ func ParseDuration(durationStr string) (Duration, error) {
 		}
 		n, _ := strconv.Atoi(matches[pos])
 
-		// Check if range overflow Time.duration ( > ~290years)
+		// Check if the provider duration overflows time.Duration (> ~ 290years).
 		if n > int((1<<63-1)/mult/time.Millisecond) {
 			overflowErr = errors.New("duration out of range")
 		}

--- a/model/time.go
+++ b/model/time.go
@@ -212,13 +212,13 @@ func ParseDuration(durationStr string) (Duration, error) {
 
 		// Check if range overflow Time.duration ( > ~290years)
 		if n > int((1<<63-1)/mult/time.Millisecond) {
-			overflowErr = errors.New("Time range overflow: Query range exceeds 290 years limit)")
+			overflowErr = errors.New("duration out of range")
 		}
 		d := time.Duration(n) * time.Millisecond
 		dur += d * mult
 
 		if dur < 0 {
-			overflowErr = errors.New("Time range overflow: Query range exceeds 290 years limit)")
+			overflowErr = errors.New("duration out of range")
 		}
 	}
 

--- a/model/time_test.go
+++ b/model/time_test.go
@@ -314,7 +314,7 @@ func TestParseBadDuration(t *testing.T) {
 		"-1w",
 		"1.5d",
 		"d",
-		"",
+		"300y",
 	}
 
 	for _, c := range cases {

--- a/model/time_test.go
+++ b/model/time_test.go
@@ -315,6 +315,7 @@ func TestParseBadDuration(t *testing.T) {
 		"1.5d",
 		"d",
 		"300y",
+		"",
 	}
 
 	for _, c := range cases {

--- a/model/time_test.go
+++ b/model/time_test.go
@@ -282,6 +282,10 @@ func TestDuration_UnmarshalJSON(t *testing.T) {
 			in:  `"10y"`,
 			out: 10 * 365 * 24 * time.Hour,
 		},
+		{
+			in:  `"289y"`,
+			out: 289 * 365 * 24 * time.Hour,
+		},
 	}
 
 	for _, c := range cases {
@@ -314,7 +318,10 @@ func TestParseBadDuration(t *testing.T) {
 		"-1w",
 		"1.5d",
 		"d",
-		"300y",
+		"294y",
+		"200y10400w",
+		"107675d",
+		"2584200h",
 		"",
 	}
 


### PR DESCRIPTION
Fix #8526 (https://github.com/prometheus/prometheus/issues/8526) issue by validating if the input range exceeds 290 years on "func ParseDuration(durationStr string) (Duration, error)".

The problem reported on this issue occurs because the "time.Duration" on Go is limited to 290 years. When you exceed this limit you get unexpected behaviours.

Fixes prometheus/prometheus#8526