### PR TITLE
Allow to customize DialContext in HTTPClientConfig

### DIFF
--- a/config/http_config_test.go
+++ b/config/http_config_test.go
@@ -16,10 +16,13 @@
 package config
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -50,6 +53,7 @@ const (
 	MissingKey            = "missing/secret.key"
 
 	ExpectedMessage                   = "I'm here to serve you!!!"
+	ExpectedError                     = "expected error"
 	AuthorizationCredentials          = "theanswertothegreatquestionoflifetheuniverseandeverythingisfortytwo"
 	AuthorizationCredentialsFile      = "testdata/bearer.token"
 	AuthorizationType                 = "APIKEY"
@@ -410,6 +414,29 @@ func TestNewClientFromInvalidConfig(t *testing.T) {
 		if !strings.Contains(err.Error(), invalidConfig.errorMsg) {
 			t.Errorf("Expected error %q does not contain %q", err.Error(), invalidConfig.errorMsg)
 		}
+	}
+}
+
+func TestCustomDialContext(t *testing.T) {
+	cfg := HTTPClientConfig{
+		DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+			return nil, errors.New(ExpectedError)
+		},
+	}
+
+	err := cfg.Validate()
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	client, err := NewClientFromConfig(cfg, "test", false, true)
+	if err != nil {
+		t.Fatalf("Can't create a client from this config: %+v", cfg)
+	}
+
+	_, err = client.Get("http://localhost")
+	if err == nil || !strings.Contains(err.Error(), ExpectedError) {
+		t.Errorf("Expected error %q but got %q", ExpectedError, err)
 	}
 }
 


### PR DESCRIPTION
In Cortex we have a use case where we would need to customize the dialer used by the HTTP client in the upstream Prometheus alertmanager. Unfortunately we can't do it without changing it upstream so, in this PR, I'm proposing to add a `DialContext` option to `HTTPClientConfig`. Is it something Prometheus is willing to accept?