### PR TITLE
Make OAuth 2.0 client_id and client_secret mandatory

### DIFF
--- a/config/http_config.go
+++ b/config/http_config.go
@@ -210,8 +210,11 @@ func (c *HTTPClientConfig) Validate() error {
 		if c.BasicAuth != nil {
 			return fmt.Errorf("at most one of basic_auth, oauth2 & authorization must be configured")
 		}
-		if len(c.OAuth2.ClientID) < 1 || (len(c.OAuth2.ClientSecret) < 1 || len(c.OAuth2.ClientSecretFile) < 1) {
+		if len(c.OAuth2.ClientID) < 1 || (len(c.OAuth2.ClientSecret) < 1 && len(c.OAuth2.ClientSecretFile) < 1) {
 			return fmt.Errorf("the oauth2 client_id and either the client_secret or client_secret_file must be configured")
+		}
+		if len(c.OAuth2.TokenURL) < 1 {
+			return fmt.Errorf("the oauth2 token_url must be configured")
 		}
 		if len(c.OAuth2.ClientSecret) > 0 && len(c.OAuth2.ClientSecretFile) > 0 {
 			return fmt.Errorf("at most one of oauth2 client_secret & client_secret_file must be configured")

--- a/config/http_config.go
+++ b/config/http_config.go
@@ -210,10 +210,13 @@ func (c *HTTPClientConfig) Validate() error {
 		if c.BasicAuth != nil {
 			return fmt.Errorf("at most one of basic_auth, oauth2 & authorization must be configured")
 		}
-		if len(c.OAuth2.ClientID) < 1 || (len(c.OAuth2.ClientSecret) < 1 && len(c.OAuth2.ClientSecretFile) < 1) {
-			return fmt.Errorf("the oauth2 client_id and either the client_secret or client_secret_file must be configured")
+		if len(c.OAuth2.ClientID) == 0 {
+			return fmt.Errorf("the oauth2 client_id must be configured")
 		}
-		if len(c.OAuth2.TokenURL) < 1 {
+		if len(c.OAuth2.ClientSecret) == 0 && len(c.OAuth2.ClientSecretFile) == 0 {
+			return fmt.Errorf("either the oauth2 client_secret or client_secret_file must be configured")
+		}
+		if len(c.OAuth2.TokenURL) == 0 {
 			return fmt.Errorf("the oauth2 token_url must be configured")
 		}
 		if len(c.OAuth2.ClientSecret) > 0 && len(c.OAuth2.ClientSecretFile) > 0 {

--- a/config/http_config.go
+++ b/config/http_config.go
@@ -210,6 +210,9 @@ func (c *HTTPClientConfig) Validate() error {
 		if c.BasicAuth != nil {
 			return fmt.Errorf("at most one of basic_auth, oauth2 & authorization must be configured")
 		}
+		if len(c.OAuth2.ClientID) < 1 || (len(c.OAuth2.ClientSecret) < 1 || len(c.OAuth2.ClientSecretFile) < 1) {
+			return fmt.Errorf("the oauth2 client_id and either the client_secret or client_secret_file must be configured")
+		}
 		if len(c.OAuth2.ClientSecret) > 0 && len(c.OAuth2.ClientSecretFile) > 0 {
 			return fmt.Errorf("at most one of oauth2 client_secret & client_secret_file must be configured")
 		}

--- a/config/http_config.go
+++ b/config/http_config.go
@@ -211,13 +211,13 @@ func (c *HTTPClientConfig) Validate() error {
 			return fmt.Errorf("at most one of basic_auth, oauth2 & authorization must be configured")
 		}
 		if len(c.OAuth2.ClientID) == 0 {
-			return fmt.Errorf("the oauth2 client_id must be configured")
+			return fmt.Errorf("oauth2 client_id must be configured")
 		}
 		if len(c.OAuth2.ClientSecret) == 0 && len(c.OAuth2.ClientSecretFile) == 0 {
-			return fmt.Errorf("either the oauth2 client_secret or client_secret_file must be configured")
+			return fmt.Errorf("either oauth2 client_secret or client_secret_file must be configured")
 		}
 		if len(c.OAuth2.TokenURL) == 0 {
-			return fmt.Errorf("the oauth2 token_url must be configured")
+			return fmt.Errorf("oauth2 token_url must be configured")
 		}
 		if len(c.OAuth2.ClientSecret) > 0 && len(c.OAuth2.ClientSecretFile) > 0 {
 			return fmt.Errorf("at most one of oauth2 client_secret & client_secret_file must be configured")

--- a/config/http_config_test.go
+++ b/config/http_config_test.go
@@ -115,6 +115,10 @@ var invalidHTTPClientConfigs = []struct {
 		httpClientConfigFile: "testdata/http.conf.oauth2-no-client-secret.bad.yaml",
 		errMsg:               "the oauth2 client_id and either the client_secret or client_secret_file must be configured",
 	},
+	{
+		httpClientConfigFile: "testdata/http.conf.oauth2-no-token-url.bad.yaml",
+		errMsg:               "the oauth2 token_url must be configured",
+	},
 }
 
 func newTestServer(handler func(w http.ResponseWriter, r *http.Request)) (*httptest.Server, error) {

--- a/config/http_config_test.go
+++ b/config/http_config_test.go
@@ -109,11 +109,11 @@ var invalidHTTPClientConfigs = []struct {
 	},
 	{
 		httpClientConfigFile: "testdata/http.conf.oauth2-no-client-id.bad.yaml",
-		errMsg:               "the oauth2 client_id and either the client_secret or client_secret_file must be configured",
+		errMsg:               "the oauth2 client_id must be configured",
 	},
 	{
 		httpClientConfigFile: "testdata/http.conf.oauth2-no-client-secret.bad.yaml",
-		errMsg:               "the oauth2 client_id and either the client_secret or client_secret_file must be configured",
+		errMsg:               "either the oauth2 client_secret or client_secret_file must be configured",
 	},
 	{
 		httpClientConfigFile: "testdata/http.conf.oauth2-no-token-url.bad.yaml",

--- a/config/http_config_test.go
+++ b/config/http_config_test.go
@@ -107,6 +107,14 @@ var invalidHTTPClientConfigs = []struct {
 		httpClientConfigFile: "testdata/http.conf.oauth2-secret-and-file-set.bad.yml",
 		errMsg:               "at most one of oauth2 client_secret & client_secret_file must be configured",
 	},
+	{
+		httpClientConfigFile: "testdata/http.conf.oauth2-no-client-id.bad.yaml",
+		errMsg:               "the oauth2 client_id and either the client_secret or client_secret_file must be configured",
+	},
+	{
+		httpClientConfigFile: "testdata/http.conf.oauth2-no-client-secret.bad.yaml",
+		errMsg:               "the oauth2 client_id and either the client_secret or client_secret_file must be configured",
+	},
 }
 
 func newTestServer(handler func(w http.ResponseWriter, r *http.Request)) (*httptest.Server, error) {

--- a/config/http_config_test.go
+++ b/config/http_config_test.go
@@ -109,15 +109,15 @@ var invalidHTTPClientConfigs = []struct {
 	},
 	{
 		httpClientConfigFile: "testdata/http.conf.oauth2-no-client-id.bad.yaml",
-		errMsg:               "the oauth2 client_id must be configured",
+		errMsg:               "oauth2 client_id must be configured",
 	},
 	{
 		httpClientConfigFile: "testdata/http.conf.oauth2-no-client-secret.bad.yaml",
-		errMsg:               "either the oauth2 client_secret or client_secret_file must be configured",
+		errMsg:               "either oauth2 client_secret or client_secret_file must be configured",
 	},
 	{
 		httpClientConfigFile: "testdata/http.conf.oauth2-no-token-url.bad.yaml",
-		errMsg:               "the oauth2 token_url must be configured",
+		errMsg:               "oauth2 token_url must be configured",
 	},
 }
 

--- a/config/testdata/http.conf.oauth2-no-client-id.bad.yaml
+++ b/config/testdata/http.conf.oauth2-no-client-id.bad.yaml
@@ -1,0 +1,2 @@
+oauth2:
+  client_secret: "mysecret"

--- a/config/testdata/http.conf.oauth2-no-client-secret.bad.yaml
+++ b/config/testdata/http.conf.oauth2-no-client-secret.bad.yaml
@@ -1,0 +1,2 @@
+oauth2:
+  client_id: "myclientid"

--- a/config/testdata/http.conf.oauth2-no-client-secret.bad.yaml
+++ b/config/testdata/http.conf.oauth2-no-client-secret.bad.yaml
@@ -1,2 +1,3 @@
 oauth2:
   client_id: "myclientid"
+  token_url: "http://auth"

--- a/config/testdata/http.conf.oauth2-no-token-url.bad.yaml
+++ b/config/testdata/http.conf.oauth2-no-token-url.bad.yaml
@@ -1,3 +1,3 @@
 oauth2:
+  client_id: "myclientid"
   client_secret: "mysecret"
-  token_url: "http://auth"

--- a/config/testdata/http.conf.oauth2-secret-and-file-set.bad.yml
+++ b/config/testdata/http.conf.oauth2-secret-and-file-set.bad.yml
@@ -1,3 +1,4 @@
 oauth2:
+  client_id: "myclient"
   client_secret: "mysecret"
   client_secret_file: "mysecret"

--- a/config/testdata/http.conf.oauth2-secret-and-file-set.bad.yml
+++ b/config/testdata/http.conf.oauth2-secret-and-file-set.bad.yml
@@ -2,3 +2,4 @@ oauth2:
   client_id: "myclient"
   client_secret: "mysecret"
   client_secret_file: "mysecret"
+  token_url: "http://auth"


### PR DESCRIPTION
These should be mandatory as per the spec.

cc @roidelapluie 