### PR TITLE
http_config: Exposes NewTLSRoundTripper method

### DIFF
--- a/config/http_config.go
+++ b/config/http_config.go
@@ -420,7 +420,7 @@ func NewRoundTripperFromConfig(cfg HTTPClientConfig, name string, optFuncs ...HT
 		return newRT(tlsConfig)
 	}
 
-	return newTLSRoundTripper(tlsConfig, cfg.TLSConfig.CAFile, newRT)
+	return NewTLSRoundTripper(tlsConfig, cfg.TLSConfig.CAFile, newRT)
 }
 
 type authorizationCredentialsRoundTripper struct {
@@ -717,7 +717,7 @@ type tlsRoundTripper struct {
 	tlsConfig  *tls.Config
 }
 
-func newTLSRoundTripper(
+func NewTLSRoundTripper(
 	cfg *tls.Config,
 	caFile string,
 	newRT func(*tls.Config) (http.RoundTripper, error),


### PR DESCRIPTION

Exposes `NewTLSRoundTripper` method, Required here https://github.com/thanos-io/thanos/pull/4104

https://github.com/thanos-io/thanos/pull/4104#discussion_r634205978

Signed-off-by: someshkoli <kolisomesh27@gmail.com>