### PR TITLE
Add WithIdleConnTimeout HTTP client option

### DIFF
--- a/config/http_config_test.go
+++ b/config/http_config_test.go
@@ -456,6 +456,25 @@ func TestCustomDialContextFunc(t *testing.T) {
 	}
 }
 
+func TestCustomIdleConnTimeout(t *testing.T) {
+	timeout := time.Second * 5
+
+	cfg := HTTPClientConfig{}
+	rt, err := NewRoundTripperFromConfig(cfg, "test", WithIdleConnTimeout(timeout))
+	if err != nil {
+		t.Fatalf("Can't create a round-tripper from this config: %+v", cfg)
+	}
+
+	transport, ok := rt.(*http.Transport)
+	if !ok {
+		t.Fatalf("Unexpected transport: %+v", transport)
+	}
+
+	if transport.IdleConnTimeout != timeout {
+		t.Fatalf("Unexpected idle connection timeout: %+v", timeout)
+	}
+}
+
 func TestMissingBearerAuthFile(t *testing.T) {
 	cfg := HTTPClientConfig{
 		BearerTokenFile: MissingBearerTokenFile,


### PR DESCRIPTION
This change enables HTTP long-polling SD mechanisms to configure the idle connection timeout so that they can use this config lib to create HTTP clients.

For example, the `consul_sd` manually creates a `http.Transport`: 
https://github.com/prometheus/prometheus/blob/7bc11dcb06640ce22b4e15eb52b2c065f97cf79a/discovery/consul/consul.go#L191-L198
