### PR TITLE
Add sigv4 config to common

### DIFF
--- a/config/sigv4_config.go
+++ b/config/sigv4_config.go
@@ -1,0 +1,42 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import "fmt"
+
+// SigV4Config is the configuration for signing remote write requests with
+// AWS's SigV4 verification process. Empty values will be retrieved using the
+// AWS default credentials chain.
+type SigV4Config struct {
+	Region    string `yaml:"region,omitempty"`
+	AccessKey string `yaml:"access_key,omitempty"`
+	SecretKey Secret `yaml:"secret_key,omitempty"`
+	Profile   string `yaml:"profile,omitempty"`
+	RoleARN   string `yaml:"role_arn,omitempty"`
+}
+
+func (c *SigV4Config) Validate() error {
+	if (c.AccessKey == "") != (c.SecretKey == "") {
+		return fmt.Errorf("must provide a AWS SigV4 Access key and Secret Key if credentials are specified in the SigV4 config")
+	}
+	return nil
+}
+func (c *SigV4Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	type plain SigV4Config
+	*c = SigV4Config{}
+	if err := unmarshal((*plain)(c)); err != nil {
+		return err
+	}
+	return c.Validate()
+}

--- a/config/sigv4_config_test.go
+++ b/config/sigv4_config_test.go
@@ -1,0 +1,59 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v2"
+)
+
+func loadSigv4Config(filename string) (*SigV4Config, error) {
+	content, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	cfg := SigV4Config{}
+	if err = yaml.UnmarshalStrict(content, &cfg); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+func testGoodConfig(t *testing.T, filename string) {
+	_, err := loadSigv4Config(filename)
+	if err != nil {
+		t.Fatalf("Unexpected error parsing %s: %s", filename, err)
+	}
+}
+
+func TestGoodSigV4Configs(t *testing.T) {
+	filesToTest := []string{"testdata/sigv4_good.yaml", "testdata/sigv4_good.yaml"}
+	for _, filename := range filesToTest {
+		testGoodConfig(t, filename)
+	}
+}
+
+func TestBadSigV4Config(t *testing.T) {
+	filename := "testdata/sigv4_bad.yaml"
+	_, err := loadSigv4Config(filename)
+	if err == nil {
+		t.Fatalf("Did not receive expected error unmarshaling bad sigv4 config")
+	}
+	if !strings.Contains(err.Error(), "must provide a AWS SigV4 Access key and Secret Key") {
+		t.Errorf("Received unexpected error from unmarshal of %s: %s", filename, err.Error())
+	}
+}

--- a/config/testdata/sigv4_bad.yaml
+++ b/config/testdata/sigv4_bad.yaml
@@ -1,0 +1,4 @@
+region: us-east-2
+access_key: AccessKey
+profile: profile
+role_arn: blah:role/arn

--- a/config/testdata/sigv4_good.yaml
+++ b/config/testdata/sigv4_good.yaml
@@ -1,0 +1,5 @@
+region: us-east-2
+access_key: AccessKey
+secret_key: SecretKey
+profile: profile
+role_arn: blah:role/arn

--- a/config/testdata/sigv4_good_empty_keys.yaml
+++ b/config/testdata/sigv4_good_empty_keys.yaml
@@ -1,0 +1,3 @@
+region: us-east-2
+profile: profile
+role_arn: blah:role/arn


### PR DESCRIPTION
As requested here: https://github.com/prometheus/alertmanager/issues/2559#issuecomment-837374230
Will throw error if a user doesn't supply username and secret key

Signed-off-by: Tyler Reid <tyler.reid@grafana.com>