### PR TITLE
Add openmetrics format parser

### DIFF
--- a/expfmt/openmetrics_parse.go
+++ b/expfmt/openmetrics_parse.go
@@ -1,0 +1,337 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package expfmt
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/golang/protobuf/proto"
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/pkg/textparse"
+)
+
+// OpenMetricsParser is wrapped around original openmetricsparse.
+// zero value is ready to use.
+type OpenMetricsParser struct {
+	metricFamiliesByName map[string]*dto.MetricFamily
+	reader               *bufio.Reader    // Where the parsed input is read through.
+	buffer               *bytes.Buffer    // Input is read into buffer before parsing.
+	p                    textparse.Parser // The underline parser for parsing openmetrics text format.
+	// Key is created with LabelsToSignature.
+	summaries map[uint64]*dto.Metric
+	// Key is created with LabelsToSignature.
+	histograms map[uint64]*dto.Metric
+}
+
+// OpenMetricsToMetricFamilies reads 'in' as the openmetrics text exchange format and
+// creates MetricFamily proto messages. It returns the MetricFamily proto
+// messages in a map where the metric names are the keys, along with any
+// error encountered.
+//
+// If the input contains duplicate metrics (i.e. lines with the same metric name
+// and exactly the same label set), the resulting MetricFamily will contain
+// duplicate Metric proto messages. Similar is true for duplicate label
+// names. Checks for duplicates have to be performed separately, if required.
+// Also note that neither the metrics within each MetricFamily are sorted nor
+// the label pairs within each Metric. Sorting is not required for the most
+// frequent use of this method, which is sample ingestion in the Prometheus
+// server. However, for presentation purposes, you might want to sort the
+// metrics, and in some cases, you must sort the labels, e.g. for consumption by
+// the metric family injection hook of the Prometheus registry.
+//
+// - Can deal with Counter, Gauge, Histogram, Summary, Untyped metrics types.
+//
+// - No supported for the following (optional) features: `# UNIT` line, `_created`
+//   info type, stateset type, gaugehistogram type which defined at
+//   https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#metric-types
+//
+// - No supported for exemplar.
+//
+// This method must not be called concurrently. If you want to parse different
+// input concurrently, instantiate a separate Parser for each goroutine.
+func (p *OpenMetricsParser) OpenMetricsToMetricFamilies(in io.Reader) (map[string]*dto.MetricFamily, error) {
+	if err := p.reset(in); err != nil {
+		return nil, fmt.Errorf("reset error:%v", err)
+	}
+	var currentMF *dto.MetricFamily
+	var currentMetric *dto.Metric
+	currentIsSummaryCount := false
+	currentIsSummarySum := false
+	currentIsHistogramCount := false
+	currentIsHistogramSum := false
+	for {
+		e, err := p.p.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("parse error:%v", err)
+		}
+		switch e {
+		case textparse.EntryInvalid:
+			continue
+		case textparse.EntryType:
+			n, t := p.p.Type()
+			if currentMF = p.metricFamiliesByName[string(n)]; currentMF != nil && currentMF.Type != nil {
+				return nil, fmt.Errorf("duplicate type for metric %q", currentMF.GetName())
+			}
+			if currentMF == nil {
+				currentMF = &dto.MetricFamily{Name: proto.String(string(n))}
+				p.metricFamiliesByName[string(n)] = currentMF
+			}
+			var metricType dto.MetricType
+			if currentMF.Type == nil {
+				switch strings.ToUpper(string(t)) {
+				case "COUNTER":
+					metricType = dto.MetricType_COUNTER
+					// Add counter type metric name with the suffix '_total'.
+					if !strings.HasSuffix(currentMF.GetName(), "_total") {
+						currentMF.Name = proto.String(currentMF.GetName() + "_total")
+					}
+				case "GAUGE":
+					metricType = dto.MetricType_GAUGE
+				case "UNKNOWN":
+					metricType = dto.MetricType_UNTYPED
+				case "SUMMARY":
+					metricType = dto.MetricType_SUMMARY
+				case "HISTOGRAM":
+					metricType = dto.MetricType_HISTOGRAM
+				default:
+					return nil, fmt.Errorf("unknow metric type %q", t)
+				}
+				currentMF.Type = metricType.Enum()
+			}
+		case textparse.EntryHelp:
+			n, h := p.p.Help()
+			if currentMF = p.metricFamiliesByName[string(n)]; currentMF != nil && currentMF.Help != nil {
+				return nil, fmt.Errorf("duplicate help for metric %q", currentMF.GetName())
+			}
+			if currentMF == nil {
+				currentMF = &dto.MetricFamily{Name: proto.String(string(n)), Help: proto.String(string(h))}
+				p.metricFamiliesByName[string(n)] = currentMF
+			}
+			if currentMF.Help == nil {
+				currentMF.Help = proto.String(string(h))
+			}
+		case textparse.EntrySeries:
+			lbs := labels.Labels{}
+			p.p.Metric(&lbs)
+			name := lbs.Get(model.MetricNameLabel)
+			m := make(map[string]struct{})
+			for _, lb := range lbs {
+				if _, exists := m[lb.Name]; exists {
+					return nil, fmt.Errorf("duplicate label name %q for metric %q", lb.Name, name)
+				}
+				m[lb.Name] = struct{}{}
+			}
+			_, ts, v := p.p.Series()
+			// Reset the status.
+			currentIsSummaryCount = false
+			currentIsSummarySum = false
+			currentIsHistogramCount = false
+			currentIsHistogramSum = false
+			counterName := openMetricsCounterName(name)
+			summaryName := summaryMetricName(name)
+			histogramName := histogramMetricName(name)
+			if currentMF = p.metricFamiliesByName[name]; currentMF != nil {
+				// Do nothing.
+			} else if currentMF = p.metricFamiliesByName[counterName]; currentMF != nil && currentMF.GetType() == dto.MetricType_COUNTER {
+				// Do nothing.
+			} else if currentMF = p.metricFamiliesByName[summaryName]; currentMF != nil && currentMF.GetType() == dto.MetricType_SUMMARY {
+				if isCount(name) {
+					currentIsSummaryCount = true
+				}
+				if isSum(name) {
+					currentIsSummarySum = true
+				}
+			} else if currentMF = p.metricFamiliesByName[histogramName]; currentMF != nil && currentMF.GetType() == dto.MetricType_HISTOGRAM {
+				if isCount(name) {
+					currentIsHistogramCount = true
+				}
+				if isSum(name) {
+					currentIsHistogramSum = true
+				}
+			} else {
+				currentMF = &dto.MetricFamily{Name: proto.String(name), Type: dto.MetricType_UNTYPED.Enum()}
+				p.metricFamiliesByName[name] = currentMF
+			}
+			currentMetric = &dto.Metric{}
+			currentMetricType := currentMF.GetType()
+			switch currentMetricType {
+			case dto.MetricType_COUNTER, dto.MetricType_GAUGE, dto.MetricType_UNTYPED:
+				currentMF.Metric = append(currentMF.Metric, currentMetric)
+				switch currentMetricType {
+				case dto.MetricType_COUNTER:
+					currentMetric.Counter = &dto.Counter{Value: proto.Float64(v)}
+				case dto.MetricType_GAUGE:
+					currentMetric.Gauge = &dto.Gauge{Value: proto.Float64(v)}
+				case dto.MetricType_UNTYPED:
+					currentMetric.Untyped = &dto.Untyped{Value: proto.Float64(v)}
+				}
+				for _, lb := range lbs {
+					if lb.Name != model.MetricNameLabel {
+						currentMetric.Label = append(currentMetric.Label,
+							&dto.LabelPair{Name: proto.String(lb.Name), Value: proto.String(lb.Value)})
+					}
+				}
+				if ts != nil {
+					currentMetric.TimestampMs = proto.Int64(*ts)
+				}
+			case dto.MetricType_SUMMARY:
+				m := map[string]string{}
+				for _, lb := range lbs {
+					if !(lb.Name == model.MetricNameLabel || lb.Name == model.QuantileLabel) {
+						m[lb.Name] = lb.Value
+					}
+				}
+				m[model.MetricNameLabel] = *currentMF.Name
+				signature := model.LabelsToSignature(m)
+				if summary := p.summaries[signature]; summary != nil {
+					currentMetric = summary
+				} else {
+					p.summaries[signature] = currentMetric
+					currentMF.Metric = append(currentMF.Metric, currentMetric)
+					delete(m, model.MetricNameLabel)
+					lbs := labels.FromMap(m)
+					for _, lb := range lbs {
+						currentMetric.Label = append(currentMetric.Label,
+							&dto.LabelPair{Name: proto.String(lb.Name),
+								Value: proto.String(lb.Value)})
+					}
+				}
+				if currentMetric.Summary == nil {
+					currentMetric.Summary = &dto.Summary{}
+				}
+				if currentIsSummaryCount {
+					currentMetric.Summary.SampleCount = proto.Uint64(uint64(v))
+				}
+				if currentIsSummarySum {
+					currentMetric.Summary.SampleSum = proto.Float64(v)
+				}
+				if qs := lbs.Get(model.QuantileLabel); qs != "" {
+					quantile, err := parseFloat(qs)
+					if err != nil {
+						return nil, fmt.Errorf("parse metric %q quantile failed:%v", name, err)
+					}
+					currentMetric.Summary.Quantile = append(
+						currentMetric.Summary.Quantile,
+						&dto.Quantile{Quantile: proto.Float64(quantile), Value: proto.Float64(v)})
+				}
+				if ts != nil {
+					currentMetric.TimestampMs = proto.Int64(*ts)
+				}
+			case dto.MetricType_HISTOGRAM:
+				m := map[string]string{}
+				for _, lb := range lbs {
+					if !(lb.Name == model.MetricNameLabel || lb.Name == model.BucketLabel) {
+						m[lb.Name] = lb.Value
+					}
+				}
+				m[model.MetricNameLabel] = *currentMF.Name
+				signature := model.LabelsToSignature(m)
+				if histogram := p.histograms[signature]; histogram != nil {
+					currentMetric = histogram
+				} else {
+					p.histograms[signature] = currentMetric
+					currentMF.Metric = append(currentMF.Metric, currentMetric)
+					delete(m, model.MetricNameLabel)
+					lbs := labels.FromMap(m)
+					for _, lb := range lbs {
+						currentMetric.Label = append(currentMetric.Label,
+							&dto.LabelPair{Name: proto.String(lb.Name),
+								Value: proto.String(lb.Value)})
+					}
+				}
+				if currentMetric.Histogram == nil {
+					currentMetric.Histogram = &dto.Histogram{}
+				}
+				if currentIsHistogramCount {
+					currentMetric.Histogram.SampleCount = proto.Uint64(uint64(v))
+				}
+				if currentIsHistogramSum {
+					currentMetric.Histogram.SampleSum = proto.Float64(v)
+				}
+				if bs := lbs.Get(model.BucketLabel); bs != "" {
+					bucket, err := parseFloat(bs)
+					if err != nil {
+						return nil, fmt.Errorf("parse metric %q quantile failed:%v", name, err)
+					}
+					currentMetric.Histogram.Bucket = append(
+						currentMetric.Histogram.Bucket,
+						&dto.Bucket{UpperBound: proto.Float64(bucket), CumulativeCount: proto.Uint64(uint64(v))})
+				}
+				if ts != nil {
+					currentMetric.TimestampMs = proto.Int64(*ts)
+				}
+			}
+		case textparse.EntryComment:
+			continue
+		case textparse.EntryUnit:
+			continue
+		}
+	}
+	for k, mf := range p.metricFamiliesByName {
+		if len(mf.GetMetric()) == 0 {
+			delete(p.metricFamiliesByName, k)
+		}
+	}
+	return p.metricFamiliesByName, nil
+}
+
+func (p *OpenMetricsParser) reset(in io.Reader) error {
+	if p.buffer == nil {
+		p.buffer = bytes.NewBuffer(nil)
+	} else {
+		p.buffer.Reset()
+	}
+	if p.reader == nil {
+		p.reader = bufio.NewReader(in)
+	} else {
+		p.reader.Reset(in)
+	}
+	if _, err := io.Copy(p.buffer, p.reader); err != nil {
+		return err
+	}
+	p.p = textparse.NewOpenMetricsParser(p.buffer.Bytes())
+	p.metricFamiliesByName = map[string]*dto.MetricFamily{}
+	if p.summaries == nil {
+		p.summaries = map[uint64]*dto.Metric{}
+	} else {
+		for k := range p.summaries {
+			delete(p.summaries, k)
+		}
+	}
+	if p.histograms == nil {
+		p.histograms = map[uint64]*dto.Metric{}
+	} else {
+		for k := range p.histograms {
+			delete(p.histograms, k)
+		}
+	}
+	return nil
+}
+
+func openMetricsCounterName(name string) string {
+	if len(name) > len("_total") && strings.HasSuffix(name, "_total") {
+		return name[:len(name)-6]
+	}
+	return name
+}

--- a/expfmt/openmetrics_parse_test.go
+++ b/expfmt/openmetrics_parse_test.go
@@ -12,16 +12,6 @@ import (
 
 var openMetricParser OpenMetricsParser
 
-func TestOpenMetricsParse(t *testing.T) {
-	testOpenMetricsParse(t)
-}
-
-func BenchmarkOpenMetricsParse(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		testOpenMetricsParse(b)
-	}
-}
-
 func testOpenMetricsParse(t testing.TB) {
 	var scenarios = []struct {
 		in  string
@@ -335,5 +325,15 @@ foos_total 42.0
 				)
 			}
 		}
+	}
+}
+
+func TestOpenMetricsParse(t *testing.T) {
+	testOpenMetricsParse(t)
+}
+
+func BenchmarkOpenMetricsParse(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		testOpenMetricsParse(b)
 	}
 }

--- a/expfmt/openmetrics_parse_test.go
+++ b/expfmt/openmetrics_parse_test.go
@@ -1,0 +1,339 @@
+package expfmt
+
+import (
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+
+	dto "github.com/prometheus/client_model/go"
+)
+
+var openMetricParser OpenMetricsParser
+
+func TestOpenMetricsParse(t *testing.T) {
+	testOpenMetricsParse(t)
+}
+
+func BenchmarkOpenMetricsParse(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		testOpenMetricsParse(b)
+	}
+}
+
+func testOpenMetricsParse(t testing.TB) {
+	var scenarios = []struct {
+		in  string
+		out []*dto.MetricFamily
+	}{
+		// 0: Counter, timestamp given, no _total suffix.
+		{
+			in: `# HELP name two-line\n doc  str\\ing
+# TYPE name counter
+name_total{labelname="val1",basename="basevalue"} 42.0
+name_total{labelname="val2",basename="basevalue"} 0.23 1.23456789e+06
+# EOF`,
+			out: []*dto.MetricFamily{&dto.MetricFamily{
+				Name: proto.String("name_total"),
+				Help: proto.String("two-line\n doc  str\\ing"),
+				Type: dto.MetricType_COUNTER.Enum(),
+				Metric: []*dto.Metric{
+					&dto.Metric{
+						Label: []*dto.LabelPair{
+							&dto.LabelPair{
+								Name:  proto.String("basename"),
+								Value: proto.String("basevalue"),
+							},
+							&dto.LabelPair{
+								Name:  proto.String("labelname"),
+								Value: proto.String("val1"),
+							},
+						},
+						Counter: &dto.Counter{
+							Value: proto.Float64(42),
+						},
+					},
+					&dto.Metric{
+						Label: []*dto.LabelPair{
+							&dto.LabelPair{
+								Name:  proto.String("basename"),
+								Value: proto.String("basevalue"),
+							},
+							&dto.LabelPair{
+								Name:  proto.String("labelname"),
+								Value: proto.String("val2"),
+							},
+						},
+						Counter: &dto.Counter{
+							Value: proto.Float64(.23),
+						},
+						TimestampMs: proto.Int64(1234567890),
+					},
+				},
+			},
+			},
+		},
+		// 1: Gauge, some escaping required, +Inf as value, multi-byte characters in label values.
+		{
+			in: `# HELP gauge_name gauge\ndoc\nstr\"ing
+# TYPE gauge_name gauge
+gauge_name{name_1="val with\nnew line",name_2="val with \\backslash and \"quotes\""} +Inf
+gauge_name{name_1="Björn",name_2="佖佥"} 3.14e+42
+# EOF`,
+			out: []*dto.MetricFamily{
+				// 1: Gauge, some escaping required, +Inf as value, multi-byte characters in label values.
+				&dto.MetricFamily{
+					Name: proto.String("gauge_name"),
+					Help: proto.String("gauge\ndoc\nstr\"ing"),
+					Type: dto.MetricType_GAUGE.Enum(),
+					Metric: []*dto.Metric{
+						&dto.Metric{
+							Label: []*dto.LabelPair{
+								&dto.LabelPair{
+									Name:  proto.String("name_1"),
+									Value: proto.String("val with\nnew line"),
+								},
+								&dto.LabelPair{
+									Name:  proto.String("name_2"),
+									Value: proto.String("val with \\backslash and \"quotes\""),
+								},
+							},
+							Gauge: &dto.Gauge{
+								Value: proto.Float64(math.Inf(+1)),
+							},
+						},
+						&dto.Metric{
+							Label: []*dto.LabelPair{
+								&dto.LabelPair{
+									Name:  proto.String("name_1"),
+									Value: proto.String("Björn"),
+								},
+								&dto.LabelPair{
+									Name:  proto.String("name_2"),
+									Value: proto.String("佖佥"),
+								},
+							},
+							Gauge: &dto.Gauge{
+								Value: proto.Float64(3.14e42),
+							},
+						},
+					},
+				},
+			},
+		},
+		// 2: Unknown, no help, one sample with no labels and -Inf as value, another sample with one label.
+		{
+			in: `# TYPE unknown_name unknown
+unknown_name -Inf
+unknown_name{name_1="value 1"} -1.23e-45
+# EOF`,
+			out: []*dto.MetricFamily{
+				&dto.MetricFamily{
+					Name: proto.String("unknown_name"),
+					Type: dto.MetricType_UNTYPED.Enum(),
+					Metric: []*dto.Metric{
+						&dto.Metric{
+							Untyped: &dto.Untyped{
+								Value: proto.Float64(math.Inf(-1)),
+							},
+						},
+						&dto.Metric{
+							Label: []*dto.LabelPair{
+								&dto.LabelPair{
+									Name:  proto.String("name_1"),
+									Value: proto.String("value 1"),
+								},
+							},
+							Untyped: &dto.Untyped{
+								Value: proto.Float64(-1.23e-45),
+							},
+						},
+					},
+				},
+			},
+		},
+		// 3: Summary.
+		{
+			in: `# HELP summary_name summary docstring
+# TYPE summary_name summary
+summary_name{quantile="0.5"} -1.23
+summary_name{quantile="0.9"} 0.2342354
+summary_name{quantile="0.99"} 0.0
+summary_name_sum -3.4567
+summary_name_count 42
+summary_name{name_1="value 1",name_2="value 2",quantile="0.5"} 1.0
+summary_name{name_1="value 1",name_2="value 2",quantile="0.9"} 2.0
+summary_name{name_1="value 1",name_2="value 2",quantile="0.99"} 3.0
+summary_name_sum{name_1="value 1",name_2="value 2"} 2010.1971
+summary_name_count{name_1="value 1",name_2="value 2"} 4711
+# EOF`,
+
+			out: []*dto.MetricFamily{
+				&dto.MetricFamily{
+					Name: proto.String("summary_name"),
+					Help: proto.String("summary docstring"),
+					Type: dto.MetricType_SUMMARY.Enum(),
+					Metric: []*dto.Metric{
+						&dto.Metric{
+							Summary: &dto.Summary{
+								SampleCount: proto.Uint64(42),
+								SampleSum:   proto.Float64(-3.4567),
+								Quantile: []*dto.Quantile{
+									&dto.Quantile{
+										Quantile: proto.Float64(0.5),
+										Value:    proto.Float64(-1.23),
+									},
+									&dto.Quantile{
+										Quantile: proto.Float64(0.9),
+										Value:    proto.Float64(.2342354),
+									},
+									&dto.Quantile{
+										Quantile: proto.Float64(0.99),
+										Value:    proto.Float64(0),
+									},
+								},
+							},
+						},
+						&dto.Metric{
+							Label: []*dto.LabelPair{
+								&dto.LabelPair{
+									Name:  proto.String("name_1"),
+									Value: proto.String("value 1"),
+								},
+								&dto.LabelPair{
+									Name:  proto.String("name_2"),
+									Value: proto.String("value 2"),
+								},
+							},
+							Summary: &dto.Summary{
+								SampleCount: proto.Uint64(4711),
+								SampleSum:   proto.Float64(2010.1971),
+								Quantile: []*dto.Quantile{
+									&dto.Quantile{
+										Quantile: proto.Float64(0.5),
+										Value:    proto.Float64(1),
+									},
+									&dto.Quantile{
+										Quantile: proto.Float64(0.9),
+										Value:    proto.Float64(2),
+									},
+									&dto.Quantile{
+										Quantile: proto.Float64(0.99),
+										Value:    proto.Float64(3),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		// 4: histogram.
+		{
+			in: `# HELP request_duration_microseconds The response latency.
+# TYPE request_duration_microseconds histogram
+request_duration_microseconds_bucket{le="100.0"} 123
+request_duration_microseconds_bucket{le="120.0"} 412
+request_duration_microseconds_bucket{le="144.0"} 592
+request_duration_microseconds_bucket{le="172.8"} 1524
+request_duration_microseconds_bucket{le="+Inf"} 2693
+request_duration_microseconds_sum 1.7560473e+06
+request_duration_microseconds_count 2693
+# EOF`,
+			out: []*dto.MetricFamily{
+				&dto.MetricFamily{
+					Name: proto.String("request_duration_microseconds"),
+					Help: proto.String("The response latency."),
+					Type: dto.MetricType_HISTOGRAM.Enum(),
+					Metric: []*dto.Metric{
+						&dto.Metric{
+							Histogram: &dto.Histogram{
+								SampleCount: proto.Uint64(2693),
+								SampleSum:   proto.Float64(1756047.3),
+								Bucket: []*dto.Bucket{
+									&dto.Bucket{
+										UpperBound:      proto.Float64(100),
+										CumulativeCount: proto.Uint64(123),
+									},
+									&dto.Bucket{
+										UpperBound:      proto.Float64(120),
+										CumulativeCount: proto.Uint64(412),
+									},
+									&dto.Bucket{
+										UpperBound:      proto.Float64(144),
+										CumulativeCount: proto.Uint64(592),
+									},
+									&dto.Bucket{
+										UpperBound:      proto.Float64(172.8),
+										CumulativeCount: proto.Uint64(1524),
+									},
+									&dto.Bucket{
+										UpperBound:      proto.Float64(math.Inf(+1)),
+										CumulativeCount: proto.Uint64(2693),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		// 5: Simple Counter.
+		{
+			in: `# HELP foos Number of foos.
+# TYPE foos counter
+foos_total 42.0
+# EOF`,
+			out: []*dto.MetricFamily{
+				&dto.MetricFamily{
+					Name: proto.String("foos_total"),
+					Help: proto.String("Number of foos."),
+					Type: dto.MetricType_COUNTER.Enum(),
+					Metric: []*dto.Metric{
+						&dto.Metric{
+							Counter: &dto.Counter{
+								Value: proto.Float64(42),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for i, scenario := range scenarios {
+
+		out, err := openMetricParser.OpenMetricsToMetricFamilies(strings.NewReader(scenario.in))
+		if err != nil {
+			t.Errorf("%d. error: %s", i, err)
+			continue
+		}
+		if expected, got := len(scenario.out), len(out); expected != got {
+			t.Errorf(
+				"%d. expected %d MetricFamilies, got %d",
+				i, expected, got,
+			)
+		}
+		for _, expected := range scenario.out {
+			name := expected.GetName()
+			if *(expected.Type) == dto.MetricType_COUNTER {
+				name = openMetricsCounterName(expected.GetName())
+			}
+			got, ok := out[name]
+			if !ok {
+				t.Errorf(
+					"%d. expected MetricFamily %q, found none",
+					i, expected.GetName(),
+				)
+				continue
+			}
+			if expected.String() != got.String() {
+				t.Errorf(
+					"%d. expected MetricFamily %s, got %s",
+					i, expected, got,
+				)
+			}
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/prometheus/common
 
 require (
+	github.com/cespare/xxhash v1.1.0 // indirect
 	github.com/go-kit/log v0.1.0
 	github.com/golang/protobuf v1.4.3
 	github.com/julienschmidt/httprouter v1.3.0
@@ -9,6 +10,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.0
 	github.com/prometheus/client_model v0.2.0
+	github.com/prometheus/prometheus v2.5.0+incompatible
 	golang.org/x/net v0.0.0-20210525063256-abc453219eb5
 	golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,7 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -45,6 +46,8 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
+github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
+github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
@@ -179,10 +182,14 @@ github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsT
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/procfs v0.6.0 h1:mxy4L2jP6qMonqmq+aTtOx1ifVWUgG/TAmntgbh3xv4=
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
+github.com/prometheus/prometheus v1.8.2 h1:PAL466mnJw1VolZPm1OarpdUpqukUy/eX4tagia17DM=
+github.com/prometheus/prometheus v2.5.0+incompatible h1:7QPitgO2kOFG8ecuRn9O/4L9+10He72rVRJvMXrE9Hg=
+github.com/prometheus/prometheus v2.5.0+incompatible/go.mod h1:oAIUtOny2rjMX0OWN5vPR5/q/twIROJvdqnQKDdil/s=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
+github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=


### PR DESCRIPTION
This PR is for https://github.com/prometheus/prometheus/issues/8932. After think about the issue,  my solution is divide into two steps.
1. Use the **openMetricsParser** located in  https://github.com/prometheus/prometheus/tree/main/pkg/textparse  to parse the text exchange format into the **MetricFamily map** . this step is implemented in this PR.
2. Use https://github.com/prometheus/client_golang/blob/master/prometheus/testutil/promlint/promlint.go  **promlint** to check the metric foramt. If the first step is correct, i'll fastly plan to implement this.

My concern is that, firstly as the **openMetricsParser** is located in _github.com/prometheus/prometheus/_ , there may be  some hidden circular import problem, although i have tested it works. Secondly, I may be totally wrong about the right direction for solving this issue. i'm very happy to hear from any advices:)!