### PR TITLE
Refactor sigv4 in tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,24 +26,17 @@ jobs:
         - go/load-cache:
             key: v1-go<< parameters.go_version >>
     - run: make test
+    - run: cd sigv4 && make test
     - when:
         condition: << parameters.run_style >>
         steps:
         - run: make style
-    - when:
-        condition: << parameters.run_style >>
-        steps:
-          - run:
-              command: make style
-              working_directory: /go/src/github.com/prometheus/common/sigv4
+        - run: cd sigv4 && make style
     - when:
         condition: << parameters.use_gomod_cache >>
         steps:
         - go/save-cache:
             key: v1-go<< parameters.go_version >>
-    - run:
-        command: make test
-        working_directory: /go/src/github.com/prometheus/common/sigv4
     - store_test_results:
         path: test-results
 


### PR DESCRIPTION
use CD to be independant of CI tags and show in CircleCI which step is
failing.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>