### PR TITLE
Fix linter errors

### DIFF
--- a/config/http_config_test.go
+++ b/config/http_config_test.go
@@ -335,11 +335,11 @@ func TestNewClientFromConfig(t *testing.T) {
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				switch r.URL.Path {
 				case "/redirected":
-					fmt.Fprintf(w, ExpectedMessage)
+					fmt.Fprint(w, ExpectedMessage)
 				default:
 					w.Header().Set("Location", "/redirected")
 					w.WriteHeader(http.StatusFound)
-					fmt.Fprintf(w, "It should follow the redirect.")
+					fmt.Fprint(w, "It should follow the redirect.")
 				}
 			},
 		}, {
@@ -359,7 +359,7 @@ func TestNewClientFromConfig(t *testing.T) {
 				default:
 					w.Header().Set("Location", "/redirected")
 					w.WriteHeader(http.StatusFound)
-					fmt.Fprintf(w, ExpectedMessage)
+					fmt.Fprint(w, ExpectedMessage)
 				}
 			},
 		},

--- a/expfmt/decode_test.go
+++ b/expfmt/decode_test.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/proto" //nolint:staticcheck // Ignore SA1019. Need to keep deprecated package for compatibility.
 	dto "github.com/prometheus/client_model/go"
 
 	"github.com/prometheus/common/model"

--- a/expfmt/encode.go
+++ b/expfmt/encode.go
@@ -18,7 +18,7 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/proto" //nolint:staticcheck // Ignore SA1019. Need to keep deprecated package for compatibility.
 	"github.com/matttproud/golang_protobuf_extensions/pbutil"
 	"github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg"
 

--- a/expfmt/encode_test.go
+++ b/expfmt/encode_test.go
@@ -15,10 +15,11 @@ package expfmt
 
 import (
 	"bytes"
-	"github.com/golang/protobuf/proto"
-	dto "github.com/prometheus/client_model/go"
 	"net/http"
 	"testing"
+
+	"github.com/golang/protobuf/proto" //nolint:staticcheck // Ignore SA1019. Need to keep deprecated package for compatibility.
+	dto "github.com/prometheus/client_model/go"
 )
 
 func TestNegotiate(t *testing.T) {

--- a/expfmt/openmetrics_create_test.go
+++ b/expfmt/openmetrics_create_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/proto" //nolint:staticcheck // Ignore SA1019. Need to keep deprecated package for compatibility.
 	"github.com/golang/protobuf/ptypes"
 
 	dto "github.com/prometheus/client_model/go"

--- a/expfmt/text_create_test.go
+++ b/expfmt/text_create_test.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/proto" //nolint:staticcheck // Ignore SA1019. Need to keep deprecated package for compatibility.
 
 	dto "github.com/prometheus/client_model/go"
 )

--- a/expfmt/text_parse.go
+++ b/expfmt/text_parse.go
@@ -24,7 +24,7 @@ import (
 
 	dto "github.com/prometheus/client_model/go"
 
-	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/proto" //nolint:staticcheck // Ignore SA1019. Need to keep deprecated package for compatibility.
 	"github.com/prometheus/common/model"
 )
 

--- a/expfmt/text_parse_test.go
+++ b/expfmt/text_parse_test.go
@@ -18,7 +18,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/proto" //nolint:staticcheck // Ignore SA1019. Need to keep deprecated package for compatibility.
 	dto "github.com/prometheus/client_model/go"
 )
 


### PR DESCRIPTION
The linter is correctly flagging this bit:

	fmt.Fprintf(w, ExpectedMessage)

because it's a formatting function that doesn't appear to be formatting
anything (since there are not additional arguments after the formatting
string).

staticcheck has started flagging this import:

	"github.com/golang/protobuf/proto"

because that package has been rewritten and published as
google.golang.org/protobuf. The new package is not a drop-in replacement
for the old one, even if the staticcheck diagnostic suggests otherwise.
Newer versions of the old package are actually implemented in terms of
the new one. For this code base in particular, some of the text
marshalling functions have disappeared in the new package and they need
to be implemented in terms of the new reflection package. Until an
adequate solution is found, simply ignore the error.

Closes: #281

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>