### PR TITLE
Add helper method to config.Secret to load a file

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,8 @@ package config
 
 import (
 	"encoding/json"
+	"fmt"
+	"io/ioutil"
 	"path/filepath"
 )
 
@@ -46,6 +48,15 @@ func (s Secret) MarshalJSON() ([]byte, error) {
 		return json.Marshal("")
 	}
 	return json.Marshal(secretToken)
+}
+
+func (s *Secret) LoadFromFile(filename string) error {
+	buf, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return fmt.Errorf("cannot read %s: %w", filename, err)
+	}
+	*s = Secret(buf)
+	return nil
 }
 
 // DirectorySetter is a config type that contains file paths that may

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -17,6 +17,8 @@ package config
 
 import (
 	"encoding/json"
+	"io/ioutil"
+	"os"
 	"testing"
 )
 
@@ -51,5 +53,57 @@ func TestJSONMarshalSecret(t *testing.T) {
 				t.Fatalf("Secret not marshaled correctly, got '%s'", string(c))
 			}
 		})
+	}
+}
+
+func TestSecretLoadFromFile(t *testing.T) {
+	dn, err := ioutil.TempDir("", "test-secret-loadfromfile.")
+	if err != nil {
+		t.Fatalf("cannot create temporary directory: %s", err)
+	}
+	defer os.RemoveAll(dn)
+
+	fh, err := ioutil.TempFile(dn, "")
+	if err != nil {
+		t.Fatalf("cannot create temporary file: %s", err)
+	}
+
+	fn := fh.Name()
+
+	secretData := "test"
+
+	n, err := fh.WriteString(secretData)
+	if err != nil {
+		t.Fatalf("cannot write to temporary file %s: %s", fn, err)
+	}
+
+	if n != len(secretData) {
+		t.Fatalf("short write writing to temporary file %s, expecting %d, got %d", fn, len(secretData), n)
+	}
+
+	err = fh.Close()
+	if err != nil {
+		t.Fatalf("error closing temporary file %s after write: %s", fn, err)
+	}
+
+	var s Secret
+	err = s.LoadFromFile(fn)
+	if err != nil {
+		t.Fatalf("cannot read secret from temporary file %s: %s", fn, err)
+	}
+
+	if string(s) != secretData {
+		t.Fatalf("unexpected secret data, expected %q, actual %q", secretData, string(s))
+	}
+
+	err = os.Remove(fn)
+	if err != nil {
+		t.Fatalf("cannot remove temporary file %s: %s", fn, err)
+	}
+
+	// this should report an error now
+	err = s.LoadFromFile(fn)
+	if err == nil {
+		t.Fatalf("expecting error reading non-existent temporary file %s, got nil", fn)
 	}
 }


### PR DESCRIPTION
LoadFromFile is a very small helper to avoid repeating this code over
and over again.

This is related to prometheus/prometheus#8551

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>