### PR TITLE
promlog: check the log level first

### DIFF
--- a/promlog/log.go
+++ b/promlog/log.go
@@ -118,10 +118,11 @@ func New(config *Config) log.Logger {
 		l = log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
 	}
 
+	l = log.With(l, "ts", timestampFormat, "caller", log.DefaultCaller)
+
 	if config.Level != nil {
 		l = level.NewFilter(l, config.Level.o)
 	}
-	l = log.With(l, "ts", timestampFormat, "caller", log.DefaultCaller)
 	return l
 }
 


### PR DESCRIPTION
The logger returned by `level.NewFilter` will check the log level first, this avoids meaningless `caller` and `ts` calls.