### PR TITLE
Add `WithDialTLSContextFunc` option

### DIFF
--- a/config/http_config_test.go
+++ b/config/http_config_test.go
@@ -456,6 +456,23 @@ func TestCustomDialContextFunc(t *testing.T) {
 	}
 }
 
+func TestCustomDialTLSContextFunc(t *testing.T) {
+	dialFn := func(_ context.Context, _, _ string) (net.Conn, error) {
+		return nil, errors.New(ExpectedError)
+	}
+
+	cfg := HTTPClientConfig{}
+	client, err := NewClientFromConfig(cfg, "test", WithDialTLSContextFunc(dialFn))
+	if err != nil {
+		t.Fatalf("Can't create a client from this config: %+v", cfg)
+	}
+
+	_, err = client.Get("https://localhost")
+	if err == nil || !strings.Contains(err.Error(), ExpectedError) {
+		t.Errorf("Expected error %q but got %q", ExpectedError, err)
+	}
+}
+
 func TestCustomIdleConnTimeout(t *testing.T) {
 	timeout := time.Second * 5
 

--- a/model/labels.go
+++ b/model/labels.go
@@ -53,6 +53,10 @@ const (
 	// timeout used to scrape a target.
 	ScrapeTimeoutLabel = "__scrape_timeout__"
 
+	// ServerNameLabel is the name of the label that holds the TLS server name
+	// used to scrape the target.
+	ServerNameLabel = "__server_name__"
+
 	// ReservedLabelPrefix is a prefix which is not legal in user-supplied
 	// label names.
 	ReservedLabelPrefix = "__"


### PR DESCRIPTION
This PR adds needed functionality to implement https://github.com/prometheus/prometheus/issues/4827 in the form of the `WithDialTLSContextFunc` option and `__server_name__` label.

Example implementation:

```go
fn := func(ctx context.Context, network, addr string) (net.Conn, error) {
	tls := cfg.ScrapeConfig.HTTPClientConfig.TLSConfig
	tls.ServerName = target.labels.Get(model.ServerNameLabel)

	dialer := &tls.Dialer{
		Config: tls,
	}
	return dialer.DialContext(ctx, network, addr)
}

NewClientFromConfig(cfg, "", WithDialTLSContextFunc(fn))
```