### PR TITLE
Add `tls_config` field to OAuth 2.0 Config

### DIFF
--- a/config/http_config.go
+++ b/config/http_config.go
@@ -159,6 +159,9 @@ type OAuth2 struct {
 	Scopes           []string          `yaml:"scopes,omitempty" json:"scopes,omitempty"`
 	TokenURL         string            `yaml:"token_url" json:"token_url"`
 	EndpointParams   map[string]string `yaml:"endpoint_params,omitempty" json:"endpoint_params,omitempty"`
+
+	// TLSConfig is used to connect to the token URL.
+	TLSConfig TLSConfig `yaml:"tls_config,omitempty"`
 }
 
 // SetDirectory joins any relative file paths with dir.
@@ -594,7 +597,25 @@ func (rt *oauth2RoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 			EndpointParams: mapToValues(rt.config.EndpointParams),
 		}
 
-		tokenSource := config.TokenSource(context.Background())
+		tlsConfig, err := NewTLSConfig(&rt.config.TLSConfig)
+		if err != nil {
+			return nil, err
+		}
+
+		var t http.RoundTripper
+		if len(rt.config.TLSConfig.CAFile) == 0 {
+			t = &http.Transport{TLSClientConfig: tlsConfig}
+		} else {
+			t, err = NewTLSRoundTripper(tlsConfig, rt.config.TLSConfig.CAFile, func(tls *tls.Config) (http.RoundTripper, error) {
+				return &http.Transport{TLSClientConfig: tls}, nil
+			})
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		ctx := context.WithValue(context.Background(), oauth2.HTTPClient, &http.Client{Transport: t})
+		tokenSource := config.TokenSource(ctx)
 
 		rt.mtx.Lock()
 		rt.secret = secret
@@ -763,7 +784,6 @@ func NewTLSRoundTripper(
 		return nil, err
 	}
 	t.rt = rt
-
 	_, t.hashCAFile, err = t.getCAWithHash()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR adds the `tls_config` field to OAuth 2.0, which specifies the TLS configuration used to connect to the token endpoint (`token_url`).

Fixes #330