### PR TITLE
Add sigv4/README.md

### DIFF
--- a/sigv4/README.md
+++ b/sigv4/README.md
@@ -1,0 +1,12 @@
+github.com/prometheus/common/sigv4 module
+=========================================
+
+sigv4 provides a http.RoundTripper that will sign requests using
+Amazon's Signature Verification V4 signing procedure, using credentials
+from the default AWS credential chain.
+
+This is a separate module from github.com/prometheus/common to prevent
+it from having and propagating a dependency on the AWS SDK.
+
+This module is considered internal to Prometheus, without any stability
+guarantees for external usage.


### PR DESCRIPTION
I couldn't figure out why sigv4 is a separate Go module, and I imagine
other people might have the same question.

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>