### PR TITLE
.circleci: Test with go 1.17

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,12 +93,12 @@ workflows:
         name: go-<< matrix.go_version >>
         matrix:
           parameters:
-            go_version: ["1.13", "1.14", "1.15", "1.16"]
+            go_version: ["1.13", "1.14", "1.15", "1.16", "1.17"]
     - test-assets:
         name: assets-go-<< matrix.go_version >>
         matrix:
           parameters:
-            go_version: ["1.16"]
+            go_version: ["1.17"]
     - style:
         name: style
-        go_version: "1.16"
+        go_version: "1.17"

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build go1.8
 // +build go1.8
 
 package config

--- a/config/http_config.go
+++ b/config/http_config.go
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build go1.8
 // +build go1.8
 
 package config

--- a/config/http_config_test.go
+++ b/config/http_config_test.go
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build go1.8
 // +build go1.8
 
 package config

--- a/config/tls_config_test.go
+++ b/config/tls_config_test.go
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build go1.8
 // +build go1.8
 
 package config

--- a/expfmt/fuzz.go
+++ b/expfmt/fuzz.go
@@ -12,6 +12,7 @@
 // limitations under the License.
 
 // Build only when actually fuzzing
+//go:build gofuzz
 // +build gofuzz
 
 package expfmt


### PR DESCRIPTION
Adds support for go 1.17, see also: https://github.com/prometheus/client_golang/pull/950/

Probably this is also a good time to remove ancient go1.8 build tags (assuming nobody will use golang <1.8 to build nowadays).