### PR TITLE
Update label validation method to only run once per metric

### DIFF
--- a/sigv4/sigv4.go
+++ b/sigv4/sigv4.go
@@ -20,6 +20,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/textproto"
+	"path"
 	"sync"
 	"time"
 
@@ -115,9 +116,9 @@ func (rt *sigV4RoundTripper) RoundTrip(req *http.Request) (*http.Response, error
 	}()
 	req.Body = ioutil.NopCloser(seeker)
 
-	// Escape URL like documented in AWS documentation.
-	// https://docs.aws.amazon.com/sdk-for-go/api/aws/signer/v4/#pkg-overview
-	req.URL.Path = req.URL.EscapedPath()
+	// Clean path like documented in AWS documentation.
+	// https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
+	req.URL.Path = path.Clean(req.URL.Path)
 
 	// Clone the request and trim out headers that we don't want to sign.
 	signReq := req.Clone(req.Context())


### PR DESCRIPTION
This is a minor performance improvement during the label parsing stages of metric handling.

When running a profiler on an application that utilizes this library, we noticed that this validation was 1/3 of the time spent in `startLabelName` and was an easy minor performance win.

When parsing metric files with more significant numbers of tags, this validation scales poorly and leads to a significant number of maps being created/iterated through. This may cause a slight decrease in performance when parsing invalidly tagged metrics in some cases, but will increase performance on the happy path. This performance result is not noticeably faster in the performance test below due to to a low number of tags used in the unit tests.

Bench results:
This branch:
```
pkg: github.com/prometheus/common/expfmt
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
BenchmarkTextParse
BenchmarkTextParse-16     	    6176	    190301 ns/op
BenchmarkParseError
BenchmarkParseError-16    	   23068	     53793 ns/op
PASS
```

Main:
```
pkg: github.com/prometheus/common/expfmt
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
BenchmarkTextParse
BenchmarkTextParse-16     	    5448	    193167 ns/op
BenchmarkParseError
BenchmarkParseError-16    	   22438	     54203 ns/op
PASS
```


When tested in isolation a more clear performance improvement is shown. The happy path test is tested with with 25 metrics, each containing 8 tags. The error case is tested with one metric with 9 tags, the last being a duplicate of the first.
This branch:
```
pkg: github.com/prometheus/common/expfmt
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
BenchmarkTextParse
BenchmarkTextParse-16     	    9082	    113003 ns/op
BenchmarkParseError
BenchmarkParseError-16    	  294361	      4102 ns/op
PASS
```

Main:
```
pkg: github.com/prometheus/common/expfmt
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
BenchmarkTextParse
BenchmarkTextParse-16     	    7752	    140930 ns/op
BenchmarkParseError
BenchmarkParseError-16    	  253125	      5157 ns/op
PASS
```