### PR TITLE
Remove go 1.15

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,6 @@ workflows:
           matrix:
             parameters:
               go_version:
-                - "1.15"
                 - "1.16"
                 - "1.17"
       - test-assets:

--- a/go.mod
+++ b/go.mod
@@ -14,4 +14,4 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 )
 
-go 1.15
+go 1.16

--- a/sigv4/go.mod
+++ b/sigv4/go.mod
@@ -1,7 +1,5 @@
 module github.com/prometheus/common/sigv4
 
-go 1.15
-
 require (
 	github.com/aws/aws-sdk-go v1.43.26
 	github.com/prometheus/client_golang v1.12.1
@@ -9,3 +7,5 @@ require (
 	github.com/stretchr/testify v1.7.1
 	gopkg.in/yaml.v2 v2.4.0
 )
+
+go 1.16


### PR DESCRIPTION
Removes go 1.15 / sets minimum go version to 1.16.
See also: https://github.com/prometheus/common/pull/371
