### PR TITLE
TLS config: Enable selection of min and max TLS version

### DIFF
--- a/config/http_config_test.go
+++ b/config/http_config_test.go
@@ -627,7 +627,9 @@ func TestTLSConfig(t *testing.T) {
 		CertFile:           ClientCertificatePath,
 		KeyFile:            ClientKeyNoPassPath,
 		ServerName:         "localhost",
-		InsecureSkipVerify: false}
+		InsecureSkipVerify: false,
+		MinVersion:         tls.VersionTLS12,
+	}
 
 	tlsCAChain, err := ioutil.ReadFile(TLSCAChainPath)
 	if err != nil {
@@ -640,7 +642,9 @@ func TestTLSConfig(t *testing.T) {
 	expectedTLSConfig := &tls.Config{
 		RootCAs:            rootCAs,
 		ServerName:         configTLSConfig.ServerName,
-		InsecureSkipVerify: configTLSConfig.InsecureSkipVerify}
+		InsecureSkipVerify: configTLSConfig.InsecureSkipVerify,
+		MinVersion:         tls.VersionTLS12,
+	}
 
 	tlsConfig, err := NewTLSConfig(&configTLSConfig)
 	if err != nil {
@@ -683,6 +687,7 @@ func TestTLSConfigEmpty(t *testing.T) {
 
 	expectedTLSConfig := &tls.Config{
 		InsecureSkipVerify: configTLSConfig.InsecureSkipVerify,
+		MinVersion:         tls.VersionTLS12,
 	}
 
 	tlsConfig, err := NewTLSConfig(&configTLSConfig)

--- a/config/testdata/tls_config.tlsversion.good.yml
+++ b/config/testdata/tls_config.tlsversion.good.yml
@@ -1,0 +1,1 @@
+min_version: TLS11

--- a/config/tls_config_test.go
+++ b/config/tls_config_test.go
@@ -41,10 +41,13 @@ var expectedTLSConfigs = []struct {
 }{
 	{
 		filename: "tls_config.empty.good.yml",
-		config:   &tls.Config{},
+		config:   &tls.Config{MinVersion: tls.VersionTLS12},
 	}, {
 		filename: "tls_config.insecure.good.yml",
-		config:   &tls.Config{InsecureSkipVerify: true},
+		config:   &tls.Config{InsecureSkipVerify: true, MinVersion: tls.VersionTLS12},
+	}, {
+		filename: "tls_config.tlsversion.good.yml",
+		config:   &tls.Config{MinVersion: tls.VersionTLS11},
 	},
 }
 


### PR DESCRIPTION
go1.18 changes the default minimum TLS version to 1.2.

In order not to break our users, let's make the default minimum version
configurable, with conservative defaults.

The allowed values (TLS10, ..) come from the exporter-toolkit:
https://github.com/prometheus/exporter-toolkit/blob/master/docs/web-configuration.md

TLSVersion is exported so the exporter toolkit can reuse them later.

Signed-off-by: Julien Pivotto <roidelapluie@o11y.eu>