### PR TITLE
Add ability to sign requests for all AWS services

### DIFF
--- a/sigv4/sigv4_config.go
+++ b/sigv4/sigv4_config.go
@@ -29,6 +29,7 @@ type SigV4Config struct {
 	Profile            string        `yaml:"profile,omitempty"`
 	RoleARN            string        `yaml:"role_arn,omitempty"`
 	UseFIPSSTSEndpoint bool          `yaml:"use_fips_sts_endpoint,omitempty"`
+	Service   		   string        `yaml:"service,omitempty"`
 }
 
 func (c *SigV4Config) Validate() error {

--- a/sigv4/sigv4_config_test.go
+++ b/sigv4/sigv4_config_test.go
@@ -47,6 +47,13 @@ func TestGoodSigV4Configs(t *testing.T) {
 	}
 }
 
+func TestGoodSigV4ServiceConfigs(t *testing.T) {
+	filesToTest := []string{"testdata/sigv4_good_service.yaml", "testdata/sigv4_good_service.yaml"}
+	for _, filename := range filesToTest {
+		testGoodConfig(t, filename)
+	}
+}
+
 func TestBadSigV4Config(t *testing.T) {
 	filename := "testdata/sigv4_bad.yaml"
 	_, err := loadSigv4Config(filename)

--- a/sigv4/testdata/sigv4_good_service.yaml
+++ b/sigv4/testdata/sigv4_good_service.yaml
@@ -1,0 +1,4 @@
+region: us-east-2
+profile: profile
+role_arn: blah:role/arn
+service: exectute-api


### PR DESCRIPTION
This add the ability to utilize sigv4 signing for all AWS services not
just "aps". When the newly introduced property "service" is not set in
config it will default to "aps".

I found it hard to think of a way to test this. When you have ideas, please let me know.