### PR TITLE
Add User-Agent header to oauth2 requests

### DIFF
--- a/config/testdata/http.conf.oauth2-user-agent.good.yml
+++ b/config/testdata/http.conf.oauth2-user-agent.good.yml
@@ -1,0 +1,5 @@
+oauth2:
+  client_id: "myclient"
+  client_secret: "mysecret"
+  token_url: "http://auth"
+  user_agent: "myuseragent"


### PR DESCRIPTION
This PR adds the ability to specify the User-Agent header for oauth2 requests. 

The default User-Agent: `go-http-client/1.1` is ratelimited by many sites which leads to a lot of oauth2 requests failing. 

Fixes: [384](https://github.com/prometheus/common/issues/384)