### PR TITLE
Remove ioutil

### DIFF
--- a/assets/embed_gzip_test.go
+++ b/assets/embed_gzip_test.go
@@ -15,7 +15,7 @@ package assets
 
 import (
 	"embed"
-	"io/ioutil"
+	"io"
 	"strings"
 	"testing"
 )
@@ -81,7 +81,7 @@ func TestFS(t *testing.T) {
 				return
 			}
 
-			content, err := ioutil.ReadAll(f)
+			content, err := io.ReadAll(f)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/config/generate.go
+++ b/config/generate.go
@@ -28,10 +28,10 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"math/big"
 	"net"
+	"os"
 	"time"
 )
 
@@ -170,7 +170,7 @@ func writeCertificateAndKey(path string, cert *x509.Certificate, key *rsa.Privat
 		return err
 	}
 
-	if err := ioutil.WriteFile(fmt.Sprintf("%s.crt", path), b.Bytes(), 0644); err != nil {
+	if err := os.WriteFile(fmt.Sprintf("%s.crt", path), b.Bytes(), 0644); err != nil {
 		return err
 	}
 
@@ -179,7 +179,7 @@ func writeCertificateAndKey(path string, cert *x509.Certificate, key *rsa.Privat
 		return err
 	}
 
-	if err := ioutil.WriteFile(fmt.Sprintf("%s.key", path), b.Bytes(), 0644); err != nil {
+	if err := os.WriteFile(fmt.Sprintf("%s.key", path), b.Bytes(), 0644); err != nil {
 		return err
 	}
 
@@ -239,7 +239,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	if err := ioutil.WriteFile("testdata/tls-ca-chain.pem", b.Bytes(), 0644); err != nil {
+	if err := os.WriteFile("testdata/tls-ca-chain.pem", b.Bytes(), 0644); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/config/http_config.go
+++ b/config/http_config.go
@@ -21,10 +21,10 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -571,7 +571,7 @@ func NewAuthorizationCredentialsFileRoundTripper(authType, authCredentialsFile s
 
 func (rt *authorizationCredentialsFileRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	if len(req.Header.Get("Authorization")) == 0 {
-		b, err := ioutil.ReadFile(rt.authCredentialsFile)
+		b, err := os.ReadFile(rt.authCredentialsFile)
 		if err != nil {
 			return nil, fmt.Errorf("unable to read authorization credentials file %s: %s", rt.authCredentialsFile, err)
 		}
@@ -609,7 +609,7 @@ func (rt *basicAuthRoundTripper) RoundTrip(req *http.Request) (*http.Response, e
 	}
 	req = cloneRequest(req)
 	if rt.passwordFile != "" {
-		bs, err := ioutil.ReadFile(rt.passwordFile)
+		bs, err := os.ReadFile(rt.passwordFile)
 		if err != nil {
 			return nil, fmt.Errorf("unable to read basic auth password file %s: %s", rt.passwordFile, err)
 		}
@@ -651,7 +651,7 @@ func (rt *oauth2RoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 	)
 
 	if rt.config.ClientSecretFile != "" {
-		data, err := ioutil.ReadFile(rt.config.ClientSecretFile)
+		data, err := os.ReadFile(rt.config.ClientSecretFile)
 		if err != nil {
 			return nil, fmt.Errorf("unable to read oauth2 client secret file %s: %s", rt.config.ClientSecretFile, err)
 		}
@@ -836,7 +836,7 @@ func (c *TLSConfig) getClientCertificate(*tls.CertificateRequestInfo) (*tls.Cert
 
 // readCAFile reads the CA cert file from disk.
 func readCAFile(f string) ([]byte, error) {
-	data, err := ioutil.ReadFile(f)
+	data, err := os.ReadFile(f)
 	if err != nil {
 		return nil, fmt.Errorf("unable to load specified CA cert %s: %s", f, err)
 	}

--- a/config/http_config_test.go
+++ b/config/http_config_test.go
@@ -20,7 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -124,7 +124,7 @@ var invalidHTTPClientConfigs = []struct {
 func newTestServer(handler func(w http.ResponseWriter, r *http.Request)) (*httptest.Server, error) {
 	testServer := httptest.NewUnstartedServer(http.HandlerFunc(handler))
 
-	tlsCAChain, err := ioutil.ReadFile(TLSCAChainPath)
+	tlsCAChain, err := os.ReadFile(TLSCAChainPath)
 	if err != nil {
 		return nil, fmt.Errorf("Can't read %s", TLSCAChainPath)
 	}
@@ -432,7 +432,7 @@ func TestNewClientFromConfig(t *testing.T) {
 			continue
 		}
 
-		message, err := ioutil.ReadAll(response.Body)
+		message, err := io.ReadAll(response.Body)
 		response.Body.Close()
 		if err != nil {
 			t.Errorf("Can't read the server response body using this config: %+v", validConfig.clientConfig)
@@ -630,7 +630,7 @@ func TestTLSConfig(t *testing.T) {
 		InsecureSkipVerify: false,
 	}
 
-	tlsCAChain, err := ioutil.ReadFile(TLSCAChainPath)
+	tlsCAChain, err := os.ReadFile(TLSCAChainPath)
 	if err != nil {
 		t.Fatalf("Can't read the CA certificate chain (%s)",
 			TLSCAChainPath)
@@ -833,7 +833,7 @@ func getCertificateBlobs(t *testing.T) map[string][]byte {
 	}
 	bs := make(map[string][]byte, len(files)+1)
 	for _, f := range files {
-		b, err := ioutil.ReadFile(f)
+		b, err := os.ReadFile(f)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -848,7 +848,7 @@ func writeCertificate(bs map[string][]byte, src string, dst string) {
 	if !ok {
 		panic(fmt.Sprintf("Couldn't find %q in bs", src))
 	}
-	if err := ioutil.WriteFile(dst, b, 0664); err != nil {
+	if err := os.WriteFile(dst, b, 0664); err != nil {
 		panic(err)
 	}
 }
@@ -856,7 +856,7 @@ func writeCertificate(bs map[string][]byte, src string, dst string) {
 func TestTLSRoundTripper(t *testing.T) {
 	bs := getCertificateBlobs(t)
 
-	tmpDir, err := ioutil.TempDir("", "tlsroundtripper")
+	tmpDir, err := os.MkdirTemp("", "tlsroundtripper")
 	if err != nil {
 		t.Fatal("Failed to create tmp dir", err)
 	}
@@ -976,7 +976,7 @@ func TestTLSRoundTripper(t *testing.T) {
 				t.Fatalf("Can't connect to the test server")
 			}
 
-			b, err := ioutil.ReadAll(r.Body)
+			b, err := io.ReadAll(r.Body)
 			r.Body.Close()
 			if err != nil {
 				t.Errorf("Can't read the server response body")
@@ -993,7 +993,7 @@ func TestTLSRoundTripper(t *testing.T) {
 func TestTLSRoundTripperRaces(t *testing.T) {
 	bs := getCertificateBlobs(t)
 
-	tmpDir, err := ioutil.TempDir("", "tlsroundtripper")
+	tmpDir, err := os.MkdirTemp("", "tlsroundtripper")
 	if err != nil {
 		t.Fatal("Failed to create tmp dir", err)
 	}
@@ -1137,7 +1137,7 @@ func LoadHTTPConfig(s string) (*HTTPClientConfig, error) {
 
 // LoadHTTPConfigFile parses the given YAML file into a HTTPClientConfig.
 func LoadHTTPConfigFile(filename string) (*HTTPClientConfig, []byte, error) {
-	content, err := ioutil.ReadFile(filename)
+	content, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1305,7 +1305,7 @@ func TestOAuth2WithFile(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	secretFile, err := ioutil.TempFile("", "oauth2_secret")
+	secretFile, err := os.CreateTemp("", "oauth2_secret")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/config/tls_config_test.go
+++ b/config/tls_config_test.go
@@ -17,7 +17,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -29,7 +29,7 @@ import (
 
 // LoadTLSConfig parses the given file into a tls.Config.
 func LoadTLSConfig(filename string) (*tls.Config, error) {
-	content, err := ioutil.ReadFile(filename)
+	content, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/expfmt/bench_test.go
+++ b/expfmt/bench_test.go
@@ -17,7 +17,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"io"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/matttproud/golang_protobuf_extensions/pbutil"
@@ -47,7 +47,7 @@ var parser TextParser
 // family DTOs.
 func BenchmarkParseText(b *testing.B) {
 	b.StopTimer()
-	data, err := ioutil.ReadFile("testdata/text")
+	data, err := os.ReadFile("testdata/text")
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -64,7 +64,7 @@ func BenchmarkParseText(b *testing.B) {
 // into metric family DTOs.
 func BenchmarkParseTextGzip(b *testing.B) {
 	b.StopTimer()
-	data, err := ioutil.ReadFile("testdata/text.gz")
+	data, err := os.ReadFile("testdata/text.gz")
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -89,7 +89,7 @@ func BenchmarkParseTextGzip(b *testing.B) {
 // protobuf-format guarantees bundling at one place.)
 func BenchmarkParseProto(b *testing.B) {
 	b.StopTimer()
-	data, err := ioutil.ReadFile("testdata/protobuf")
+	data, err := os.ReadFile("testdata/protobuf")
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -114,7 +114,7 @@ func BenchmarkParseProto(b *testing.B) {
 // protobuf format.
 func BenchmarkParseProtoGzip(b *testing.B) {
 	b.StopTimer()
-	data, err := ioutil.ReadFile("testdata/protobuf.gz")
+	data, err := os.ReadFile("testdata/protobuf.gz")
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -144,7 +144,7 @@ func BenchmarkParseProtoGzip(b *testing.B) {
 // separate it from the overhead of the text format parsing.
 func BenchmarkParseProtoMap(b *testing.B) {
 	b.StopTimer()
-	data, err := ioutil.ReadFile("testdata/protobuf")
+	data, err := os.ReadFile("testdata/protobuf")
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/expfmt/text_create.go
+++ b/expfmt/text_create.go
@@ -17,7 +17,6 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"strconv"
 	"strings"
@@ -44,7 +43,7 @@ const (
 var (
 	bufPool = sync.Pool{
 		New: func() interface{} {
-			return bufio.NewWriter(ioutil.Discard)
+			return bufio.NewWriter(io.Discard)
 		},
 	}
 	numBufPool = sync.Pool{

--- a/sigv4/sigv4.go
+++ b/sigv4/sigv4.go
@@ -17,7 +17,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/textproto"
 	"path"
@@ -114,7 +113,7 @@ func (rt *sigV4RoundTripper) RoundTrip(req *http.Request) (*http.Response, error
 	defer func() {
 		_, _ = seeker.Seek(0, io.SeekStart)
 	}()
-	req.Body = ioutil.NopCloser(seeker)
+	req.Body = io.NopCloser(seeker)
 
 	// Clean path like documented in AWS documentation.
 	// https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html

--- a/sigv4/sigv4_config_test.go
+++ b/sigv4/sigv4_config_test.go
@@ -14,7 +14,7 @@
 package sigv4
 
 import (
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -22,7 +22,7 @@ import (
 )
 
 func loadSigv4Config(filename string) (*SigV4Config, error) {
-	content, err := ioutil.ReadFile(filename)
+	content, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
`ioutil` is deprecated from go1.16 (ref: https://go.dev/doc/go1.16#ioutil).
So removed them.

Signed-off-by: inosato <si17_21@yahoo.co.jp>