### PR TITLE
Add support for proxy connect headers

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	"encoding/json"
+	"net/http"
 	"path/filepath"
 )
 
@@ -46,6 +47,29 @@ func (s Secret) MarshalJSON() ([]byte, error) {
 		return json.Marshal("")
 	}
 	return json.Marshal(secretToken)
+}
+
+type Header map[string][]Secret
+
+func (h *Header) HTTPHeader() http.Header {
+	if h == nil || *h == nil {
+		return nil
+	}
+
+	header := make(http.Header)
+
+	for name, values := range *h {
+		var s []string
+		if values != nil {
+			s = make([]string, 0, len(values))
+			for _, value := range values {
+				s = append(s, string(value))
+			}
+		}
+		header[name] = s
+	}
+
+	return header
 }
 
 // DirectorySetter is a config type that contains file paths that may

--- a/config/testdata/http.conf.proxy-headers.bad.json
+++ b/config/testdata/http.conf.proxy-headers.bad.json
@@ -1,0 +1,11 @@
+{
+    "proxy_connect_header": {
+	"single": [
+	    "value_0"
+	],
+	"multi": [
+	    "value_1",
+	    "value_2"
+	]
+    }
+}

--- a/config/testdata/http.conf.proxy-headers.bad.yml
+++ b/config/testdata/http.conf.proxy-headers.bad.yml
@@ -1,0 +1,6 @@
+proxy_connect_header:
+  single:
+    - value_0
+  multi:
+    - value_1
+    - value_2

--- a/config/testdata/http.conf.proxy-headers.good.json
+++ b/config/testdata/http.conf.proxy-headers.good.json
@@ -1,0 +1,12 @@
+{
+    "proxy_url": "http://remote.host",
+    "proxy_connect_header": {
+	"single": [
+	    "value_0"
+	],
+	"multi": [
+	    "value_1",
+	    "value_2"
+	]
+    }
+}

--- a/config/testdata/http.conf.proxy-headers.good.yml
+++ b/config/testdata/http.conf.proxy-headers.good.yml
@@ -1,0 +1,7 @@
+proxy_url: "http://remote.host"
+proxy_connect_header:
+  single:
+    - value_0
+  multi:
+    - value_1
+    - value_2


### PR DESCRIPTION
Some proxy configurations require additional headers to be able to use them (e.g. authorization token specific to the proxy).

Fixes: #402
Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>