### PR TITLE
feat: make LoadHTTPConfigFile set directory and move from tests file

### DIFF
--- a/config/http_config.go
+++ b/config/http_config.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -246,6 +247,30 @@ func (a *OAuth2) SetDirectory(dir string) {
 	}
 	a.ClientSecretFile = JoinDir(dir, a.ClientSecretFile)
 	a.TLSConfig.SetDirectory(dir)
+}
+
+// LoadHTTPConfig parses the YAML input s into a HTTPClientConfig.
+func LoadHTTPConfig(s string) (*HTTPClientConfig, error) {
+	cfg := &HTTPClientConfig{}
+	err := yaml.UnmarshalStrict([]byte(s), cfg)
+	if err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+// LoadHTTPConfigFile parses the given YAML file into a HTTPClientConfig.
+func LoadHTTPConfigFile(filename string) (*HTTPClientConfig, []byte, error) {
+	content, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, nil, err
+	}
+	cfg, err := LoadHTTPConfig(string(content))
+	if err != nil {
+		return nil, nil, err
+	}
+	cfg.SetDirectory(filepath.Dir(filepath.Dir(filename)))
+	return cfg, content, nil
 }
 
 // HTTPClientConfig configures an HTTP client.

--- a/config/http_config_test.go
+++ b/config/http_config_test.go
@@ -1125,29 +1125,6 @@ func TestInvalidHTTPConfigs(t *testing.T) {
 	}
 }
 
-// LoadHTTPConfig parses the YAML input s into a HTTPClientConfig.
-func LoadHTTPConfig(s string) (*HTTPClientConfig, error) {
-	cfg := &HTTPClientConfig{}
-	err := yaml.UnmarshalStrict([]byte(s), cfg)
-	if err != nil {
-		return nil, err
-	}
-	return cfg, nil
-}
-
-// LoadHTTPConfigFile parses the given YAML file into a HTTPClientConfig.
-func LoadHTTPConfigFile(filename string) (*HTTPClientConfig, []byte, error) {
-	content, err := os.ReadFile(filename)
-	if err != nil {
-		return nil, nil, err
-	}
-	cfg, err := LoadHTTPConfig(string(content))
-	if err != nil {
-		return nil, nil, err
-	}
-	return cfg, content, nil
-}
-
 type roundTrip struct {
 	theResponse *http.Response
 	theError    error


### PR DESCRIPTION
Move away the functions from the test files since they are not only test helper.
For motivation, see https://github.com/prometheus/prometheus/pull/11487

Also add setting directory `cfg.SetDirectory(filepath.Dir(filepath.Dir(filename)))` as used in Alertmanager see 
https://github.com/prometheus/alertmanager/blob/1a9f55b939ab81b86428c013ae294ad80779c9b6/cli/config/http_config.go#L36

Prometheus does not use the `LoadHTTPConfigFile` function AFAIK, so the change in setting the directory won't break anything, hopefully. 

Other possibility is to avoid setting the directory and fix this on the Alertmanager side outside the common library. 
That might be safer (function is exported, so it could be breaking change for someone, possibly?) 

@roidelapluie PTAL