### PR TITLE
Bump golangci-lint to v1.50.1

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,13 +18,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.18.x
+          go-version-file: go.mod
       - name: Install snmp_exporter/generator dependencies
         run: sudo apt-get update && sudo apt-get -y install libsnmp-dev
         if: github.repository == 'prometheus/snmp_exporter'
       - name: Lint
-        uses: golangci/golangci-lint-action@v3.2.0
+        uses: golangci/golangci-lint-action@v3.3.1
         with:
-          version: v1.45.2
+          version: v1.50.1


### PR DESCRIPTION
Updates:
- ~~golangci-lint aligning CI and Makefile~~
- golangci/golangci-lint-action to `v3.3.1`
- actions/setup-go to `v3` to be able to read Go version from `go.mod`