### PR TITLE
Clean up config.Header to http.Header conversion

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -59,14 +59,17 @@ func (h *Header) HTTPHeader() http.Header {
 	header := make(http.Header)
 
 	for name, values := range *h {
-		var s []string
-		if values != nil {
-			s = make([]string, 0, len(values))
-			for _, value := range values {
-				s = append(s, string(value))
-			}
+		// HTTP allows for empty headers. The best representation of a
+		// header with a nil or empty set of values is a single empty
+		// string.
+		if len(values) == 0 {
+			header.Set(name, "")
+			continue
 		}
-		header[name] = s
+
+		for _, value := range values {
+			header.Add(name, string(value))
+		}
 	}
 
 	return header

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -70,10 +70,13 @@ func TestHeaderHTTPHeader(t *testing.T) {
 				"nil":    nil,
 			},
 			expected: http.Header{
-				"single": []string{"v1"},
-				"multi":  []string{"v1", "v2"},
-				"empty":  []string{},
-				"nil":    nil,
+				// note that the conversion from config.header
+				// to http.Header will use the canonical form
+				// of the header names.
+				"Single": []string{"v1"},
+				"Multi":  []string{"v1", "v2"},
+				"Empty":  []string{""},
+				"Nil":    []string{""},
 			},
 		},
 		"nil": {


### PR DESCRIPTION
It was pointed out by @dswarbrick that the current implementation is unnecessary as http.Header has an Add method. Header.Add canonicalizes header names, so the test needs to be adjusted, too.

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>