### PR TITLE
Replace deprecated github.com/golang/protobuf package

### DIFF
--- a/expfmt/decode_test.go
+++ b/expfmt/decode_test.go
@@ -22,7 +22,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/golang/protobuf/proto" //nolint:staticcheck // Ignore SA1019. Need to keep deprecated package for compatibility.
+	"google.golang.org/protobuf/proto"
+
 	dto "github.com/prometheus/client_model/go"
 
 	"github.com/prometheus/common/model"
@@ -100,8 +101,7 @@ mf2 4
 }
 
 func TestProtoDecoder(t *testing.T) {
-
-	var testTime = model.Now()
+	testTime := model.Now()
 
 	scenarios := []struct {
 		in       string
@@ -369,7 +369,7 @@ func TestProtoDecoder(t *testing.T) {
 }
 
 func testDiscriminatorHTTPHeader(t testing.TB) {
-	var scenarios = []struct {
+	scenarios := []struct {
 		input  map[string]string
 		output Format
 	}{
@@ -435,7 +435,7 @@ func TestExtractSamples(t *testing.T) {
 			Help: proto.String("Help for foo."),
 			Type: dto.MetricType_COUNTER.Enum(),
 			Metric: []*dto.Metric{
-				&dto.Metric{
+				{
 					Counter: &dto.Counter{
 						Value: proto.Float64(4711),
 					},
@@ -447,7 +447,7 @@ func TestExtractSamples(t *testing.T) {
 			Help: proto.String("Help for bar."),
 			Type: dto.MetricType_GAUGE.Enum(),
 			Metric: []*dto.Metric{
-				&dto.Metric{
+				{
 					Gauge: &dto.Gauge{
 						Value: proto.Float64(3.14),
 					},
@@ -459,7 +459,7 @@ func TestExtractSamples(t *testing.T) {
 			Help: proto.String("Help for bad."),
 			Type: dto.MetricType(42).Enum(),
 			Metric: []*dto.Metric{
-				&dto.Metric{
+				{
 					Gauge: &dto.Gauge{
 						Value: proto.Float64(2.7),
 					},

--- a/expfmt/encode_test.go
+++ b/expfmt/encode_test.go
@@ -18,7 +18,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/golang/protobuf/proto" //nolint:staticcheck // Ignore SA1019. Need to keep deprecated package for compatibility.
+	"google.golang.org/protobuf/proto"
+
 	dto "github.com/prometheus/client_model/go"
 )
 

--- a/expfmt/openmetrics_create_test.go
+++ b/expfmt/openmetrics_create_test.go
@@ -20,20 +20,16 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/protobuf/proto"  //nolint:staticcheck // Ignore SA1019. Need to keep deprecated package for compatibility.
-	"github.com/golang/protobuf/ptypes" //nolint:staticcheck // Ignore SA1019. Need to keep deprecated package for compatibility.
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	dto "github.com/prometheus/client_model/go"
 )
 
 func TestCreateOpenMetrics(t *testing.T) {
-	openMetricsTimestamp, err := ptypes.TimestampProto(time.Unix(12345, 600000000)) //nolint:staticcheck // Ignore SA1019. Need to keep deprecated package for compatibility.
+	openMetricsTimestamp := timestamppb.New(time.Unix(12345, 600000000))
 
-	if err != nil {
-		t.Error(err)
-	}
-
-	var scenarios = []struct {
+	scenarios := []struct {
 		in  *dto.MetricFamily
 		out string
 	}{
@@ -44,13 +40,13 @@ func TestCreateOpenMetrics(t *testing.T) {
 				Help: proto.String("two-line\n doc  str\\ing"),
 				Type: dto.MetricType_COUNTER.Enum(),
 				Metric: []*dto.Metric{
-					&dto.Metric{
+					{
 						Label: []*dto.LabelPair{
-							&dto.LabelPair{
+							{
 								Name:  proto.String("labelname"),
 								Value: proto.String("val1"),
 							},
-							&dto.LabelPair{
+							{
 								Name:  proto.String("basename"),
 								Value: proto.String("basevalue"),
 							},
@@ -59,13 +55,13 @@ func TestCreateOpenMetrics(t *testing.T) {
 							Value: proto.Float64(42),
 						},
 					},
-					&dto.Metric{
+					{
 						Label: []*dto.LabelPair{
-							&dto.LabelPair{
+							{
 								Name:  proto.String("labelname"),
 								Value: proto.String("val2"),
 							},
-							&dto.LabelPair{
+							{
 								Name:  proto.String("basename"),
 								Value: proto.String("basevalue"),
 							},
@@ -90,13 +86,13 @@ name{labelname="val2",basename="basevalue"} 0.23 1.23456789e+06
 				Help: proto.String("gauge\ndoc\nstr\"ing"),
 				Type: dto.MetricType_GAUGE.Enum(),
 				Metric: []*dto.Metric{
-					&dto.Metric{
+					{
 						Label: []*dto.LabelPair{
-							&dto.LabelPair{
+							{
 								Name:  proto.String("name_1"),
 								Value: proto.String("val with\nnew line"),
 							},
-							&dto.LabelPair{
+							{
 								Name:  proto.String("name_2"),
 								Value: proto.String("val with \\backslash and \"quotes\""),
 							},
@@ -105,13 +101,13 @@ name{labelname="val2",basename="basevalue"} 0.23 1.23456789e+06
 							Value: proto.Float64(math.Inf(+1)),
 						},
 					},
-					&dto.Metric{
+					{
 						Label: []*dto.LabelPair{
-							&dto.LabelPair{
+							{
 								Name:  proto.String("name_1"),
 								Value: proto.String("Björn"),
 							},
-							&dto.LabelPair{
+							{
 								Name:  proto.String("name_2"),
 								Value: proto.String("佖佥"),
 							},
@@ -134,14 +130,14 @@ gauge_name{name_1="Björn",name_2="佖佥"} 3.14e+42
 				Name: proto.String("unknown_name"),
 				Type: dto.MetricType_UNTYPED.Enum(),
 				Metric: []*dto.Metric{
-					&dto.Metric{
+					{
 						Untyped: &dto.Untyped{
 							Value: proto.Float64(math.Inf(-1)),
 						},
 					},
-					&dto.Metric{
+					{
 						Label: []*dto.LabelPair{
-							&dto.LabelPair{
+							{
 								Name:  proto.String("name_1"),
 								Value: proto.String("value 1"),
 							},
@@ -164,33 +160,33 @@ unknown_name{name_1="value 1"} -1.23e-45
 				Help: proto.String("summary docstring"),
 				Type: dto.MetricType_SUMMARY.Enum(),
 				Metric: []*dto.Metric{
-					&dto.Metric{
+					{
 						Summary: &dto.Summary{
 							SampleCount: proto.Uint64(42),
 							SampleSum:   proto.Float64(-3.4567),
 							Quantile: []*dto.Quantile{
-								&dto.Quantile{
+								{
 									Quantile: proto.Float64(0.5),
 									Value:    proto.Float64(-1.23),
 								},
-								&dto.Quantile{
+								{
 									Quantile: proto.Float64(0.9),
 									Value:    proto.Float64(.2342354),
 								},
-								&dto.Quantile{
+								{
 									Quantile: proto.Float64(0.99),
 									Value:    proto.Float64(0),
 								},
 							},
 						},
 					},
-					&dto.Metric{
+					{
 						Label: []*dto.LabelPair{
-							&dto.LabelPair{
+							{
 								Name:  proto.String("name_1"),
 								Value: proto.String("value 1"),
 							},
-							&dto.LabelPair{
+							{
 								Name:  proto.String("name_2"),
 								Value: proto.String("value 2"),
 							},
@@ -199,15 +195,15 @@ unknown_name{name_1="value 1"} -1.23e-45
 							SampleCount: proto.Uint64(4711),
 							SampleSum:   proto.Float64(2010.1971),
 							Quantile: []*dto.Quantile{
-								&dto.Quantile{
+								{
 									Quantile: proto.Float64(0.5),
 									Value:    proto.Float64(1),
 								},
-								&dto.Quantile{
+								{
 									Quantile: proto.Float64(0.9),
 									Value:    proto.Float64(2),
 								},
-								&dto.Quantile{
+								{
 									Quantile: proto.Float64(0.99),
 									Value:    proto.Float64(3),
 								},
@@ -237,28 +233,28 @@ summary_name_count{name_1="value 1",name_2="value 2"} 4711
 				Help: proto.String("The response latency."),
 				Type: dto.MetricType_HISTOGRAM.Enum(),
 				Metric: []*dto.Metric{
-					&dto.Metric{
+					{
 						Histogram: &dto.Histogram{
 							SampleCount: proto.Uint64(2693),
 							SampleSum:   proto.Float64(1756047.3),
 							Bucket: []*dto.Bucket{
-								&dto.Bucket{
+								{
 									UpperBound:      proto.Float64(100),
 									CumulativeCount: proto.Uint64(123),
 								},
-								&dto.Bucket{
+								{
 									UpperBound:      proto.Float64(120),
 									CumulativeCount: proto.Uint64(412),
 								},
-								&dto.Bucket{
+								{
 									UpperBound:      proto.Float64(144),
 									CumulativeCount: proto.Uint64(592),
 								},
-								&dto.Bucket{
+								{
 									UpperBound:      proto.Float64(172.8),
 									CumulativeCount: proto.Uint64(1524),
 								},
-								&dto.Bucket{
+								{
 									UpperBound:      proto.Float64(math.Inf(+1)),
 									CumulativeCount: proto.Uint64(2693),
 								},
@@ -285,24 +281,24 @@ request_duration_microseconds_count 2693
 				Help: proto.String("The response latency."),
 				Type: dto.MetricType_HISTOGRAM.Enum(),
 				Metric: []*dto.Metric{
-					&dto.Metric{
+					{
 						Histogram: &dto.Histogram{
 							SampleCount: proto.Uint64(2693),
 							SampleSum:   proto.Float64(1756047.3),
 							Bucket: []*dto.Bucket{
-								&dto.Bucket{
+								{
 									UpperBound:      proto.Float64(100),
 									CumulativeCount: proto.Uint64(123),
 								},
-								&dto.Bucket{
+								{
 									UpperBound:      proto.Float64(120),
 									CumulativeCount: proto.Uint64(412),
 								},
-								&dto.Bucket{
+								{
 									UpperBound:      proto.Float64(144),
 									CumulativeCount: proto.Uint64(592),
 								},
-								&dto.Bucket{
+								{
 									UpperBound:      proto.Float64(172.8),
 									CumulativeCount: proto.Uint64(1524),
 								},
@@ -329,21 +325,21 @@ request_duration_microseconds_count 2693
 				Help: proto.String("The response latency."),
 				Type: dto.MetricType_HISTOGRAM.Enum(),
 				Metric: []*dto.Metric{
-					&dto.Metric{
+					{
 						Histogram: &dto.Histogram{
 							SampleCount: proto.Uint64(2693),
 							SampleSum:   proto.Float64(1756047.3),
 							Bucket: []*dto.Bucket{
-								&dto.Bucket{
+								{
 									UpperBound:      proto.Float64(100),
 									CumulativeCount: proto.Uint64(123),
 								},
-								&dto.Bucket{
+								{
 									UpperBound:      proto.Float64(120),
 									CumulativeCount: proto.Uint64(412),
 									Exemplar: &dto.Exemplar{
 										Label: []*dto.LabelPair{
-											&dto.LabelPair{
+											{
 												Name:  proto.String("foo"),
 												Value: proto.String("bar"),
 											},
@@ -352,16 +348,16 @@ request_duration_microseconds_count 2693
 										Timestamp: openMetricsTimestamp,
 									},
 								},
-								&dto.Bucket{
+								{
 									UpperBound:      proto.Float64(144),
 									CumulativeCount: proto.Uint64(592),
 									Exemplar: &dto.Exemplar{
 										Label: []*dto.LabelPair{
-											&dto.LabelPair{
+											{
 												Name:  proto.String("foo"),
 												Value: proto.String("baz"),
 											},
-											&dto.LabelPair{
+											{
 												Name:  proto.String("dings"),
 												Value: proto.String("bums"),
 											},
@@ -369,7 +365,7 @@ request_duration_microseconds_count 2693
 										Value: proto.Float64(140.14),
 									},
 								},
-								&dto.Bucket{
+								{
 									UpperBound:      proto.Float64(172.8),
 									CumulativeCount: proto.Uint64(1524),
 								},
@@ -396,7 +392,7 @@ request_duration_microseconds_count 2693
 				Help: proto.String("Number of foos."),
 				Type: dto.MetricType_COUNTER.Enum(),
 				Metric: []*dto.Metric{
-					&dto.Metric{
+					{
 						Counter: &dto.Counter{
 							Value: proto.Float64(42),
 						},
@@ -442,7 +438,6 @@ foos_total 42.0
 			)
 		}
 	}
-
 }
 
 func BenchmarkOpenMetricsCreate(b *testing.B) {
@@ -451,17 +446,17 @@ func BenchmarkOpenMetricsCreate(b *testing.B) {
 		Help: proto.String("The response latency."),
 		Type: dto.MetricType_HISTOGRAM.Enum(),
 		Metric: []*dto.Metric{
-			&dto.Metric{
+			{
 				Label: []*dto.LabelPair{
-					&dto.LabelPair{
+					{
 						Name:  proto.String("name_1"),
 						Value: proto.String("val with\nnew line"),
 					},
-					&dto.LabelPair{
+					{
 						Name:  proto.String("name_2"),
 						Value: proto.String("val with \\backslash and \"quotes\""),
 					},
-					&dto.LabelPair{
+					{
 						Name:  proto.String("name_3"),
 						Value: proto.String("Just a quite long label value to test performance."),
 					},
@@ -470,40 +465,40 @@ func BenchmarkOpenMetricsCreate(b *testing.B) {
 					SampleCount: proto.Uint64(2693),
 					SampleSum:   proto.Float64(1756047.3),
 					Bucket: []*dto.Bucket{
-						&dto.Bucket{
+						{
 							UpperBound:      proto.Float64(100),
 							CumulativeCount: proto.Uint64(123),
 						},
-						&dto.Bucket{
+						{
 							UpperBound:      proto.Float64(120),
 							CumulativeCount: proto.Uint64(412),
 						},
-						&dto.Bucket{
+						{
 							UpperBound:      proto.Float64(144),
 							CumulativeCount: proto.Uint64(592),
 						},
-						&dto.Bucket{
+						{
 							UpperBound:      proto.Float64(172.8),
 							CumulativeCount: proto.Uint64(1524),
 						},
-						&dto.Bucket{
+						{
 							UpperBound:      proto.Float64(math.Inf(+1)),
 							CumulativeCount: proto.Uint64(2693),
 						},
 					},
 				},
 			},
-			&dto.Metric{
+			{
 				Label: []*dto.LabelPair{
-					&dto.LabelPair{
+					{
 						Name:  proto.String("name_1"),
 						Value: proto.String("Björn"),
 					},
-					&dto.LabelPair{
+					{
 						Name:  proto.String("name_2"),
 						Value: proto.String("佖佥"),
 					},
-					&dto.LabelPair{
+					{
 						Name:  proto.String("name_3"),
 						Value: proto.String("Just a quite long label value to test performance."),
 					},
@@ -512,19 +507,19 @@ func BenchmarkOpenMetricsCreate(b *testing.B) {
 					SampleCount: proto.Uint64(5699),
 					SampleSum:   proto.Float64(49484343543.4343),
 					Bucket: []*dto.Bucket{
-						&dto.Bucket{
+						{
 							UpperBound:      proto.Float64(100),
 							CumulativeCount: proto.Uint64(120),
 						},
-						&dto.Bucket{
+						{
 							UpperBound:      proto.Float64(120),
 							CumulativeCount: proto.Uint64(412),
 						},
-						&dto.Bucket{
+						{
 							UpperBound:      proto.Float64(144),
 							CumulativeCount: proto.Uint64(596),
 						},
-						&dto.Bucket{
+						{
 							UpperBound:      proto.Float64(172.8),
 							CumulativeCount: proto.Uint64(1535),
 						},
@@ -546,7 +541,7 @@ func BenchmarkOpenMetricsCreate(b *testing.B) {
 }
 
 func TestOpenMetricsCreateError(t *testing.T) {
-	var scenarios = []struct {
+	scenarios := []struct {
 		in  *dto.MetricFamily
 		err string
 	}{
@@ -556,7 +551,7 @@ func TestOpenMetricsCreateError(t *testing.T) {
 				Help: proto.String("doc string"),
 				Type: dto.MetricType_UNTYPED.Enum(),
 				Metric: []*dto.Metric{
-					&dto.Metric{
+					{
 						Untyped: &dto.Untyped{
 							Value: proto.Float64(math.Inf(-1)),
 						},
@@ -572,7 +567,7 @@ func TestOpenMetricsCreateError(t *testing.T) {
 				Help: proto.String("doc string"),
 				Type: dto.MetricType_COUNTER.Enum(),
 				Metric: []*dto.Metric{
-					&dto.Metric{
+					{
 						Untyped: &dto.Untyped{
 							Value: proto.Float64(math.Inf(-1)),
 						},
@@ -597,5 +592,4 @@ func TestOpenMetricsCreateError(t *testing.T) {
 			)
 		}
 	}
-
 }

--- a/expfmt/text_create_test.go
+++ b/expfmt/text_create_test.go
@@ -19,13 +19,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/golang/protobuf/proto" //nolint:staticcheck // Ignore SA1019. Need to keep deprecated package for compatibility.
+	"google.golang.org/protobuf/proto"
 
 	dto "github.com/prometheus/client_model/go"
 )
 
 func TestCreate(t *testing.T) {
-	var scenarios = []struct {
+	scenarios := []struct {
 		in  *dto.MetricFamily
 		out string
 	}{
@@ -36,13 +36,13 @@ func TestCreate(t *testing.T) {
 				Help: proto.String("two-line\n doc  str\\ing"),
 				Type: dto.MetricType_COUNTER.Enum(),
 				Metric: []*dto.Metric{
-					&dto.Metric{
+					{
 						Label: []*dto.LabelPair{
-							&dto.LabelPair{
+							{
 								Name:  proto.String("labelname"),
 								Value: proto.String("val1"),
 							},
-							&dto.LabelPair{
+							{
 								Name:  proto.String("basename"),
 								Value: proto.String("basevalue"),
 							},
@@ -51,13 +51,13 @@ func TestCreate(t *testing.T) {
 							Value: proto.Float64(math.NaN()),
 						},
 					},
-					&dto.Metric{
+					{
 						Label: []*dto.LabelPair{
-							&dto.LabelPair{
+							{
 								Name:  proto.String("labelname"),
 								Value: proto.String("val2"),
 							},
-							&dto.LabelPair{
+							{
 								Name:  proto.String("basename"),
 								Value: proto.String("basevalue"),
 							},
@@ -82,13 +82,13 @@ name{labelname="val2",basename="basevalue"} 0.23 1234567890
 				Help: proto.String("gauge\ndoc\nstr\"ing"),
 				Type: dto.MetricType_GAUGE.Enum(),
 				Metric: []*dto.Metric{
-					&dto.Metric{
+					{
 						Label: []*dto.LabelPair{
-							&dto.LabelPair{
+							{
 								Name:  proto.String("name_1"),
 								Value: proto.String("val with\nnew line"),
 							},
-							&dto.LabelPair{
+							{
 								Name:  proto.String("name_2"),
 								Value: proto.String("val with \\backslash and \"quotes\""),
 							},
@@ -97,13 +97,13 @@ name{labelname="val2",basename="basevalue"} 0.23 1234567890
 							Value: proto.Float64(math.Inf(+1)),
 						},
 					},
-					&dto.Metric{
+					{
 						Label: []*dto.LabelPair{
-							&dto.LabelPair{
+							{
 								Name:  proto.String("name_1"),
 								Value: proto.String("Björn"),
 							},
-							&dto.LabelPair{
+							{
 								Name:  proto.String("name_2"),
 								Value: proto.String("佖佥"),
 							},
@@ -126,14 +126,14 @@ gauge_name{name_1="Björn",name_2="佖佥"} 3.14e+42
 				Name: proto.String("untyped_name"),
 				Type: dto.MetricType_UNTYPED.Enum(),
 				Metric: []*dto.Metric{
-					&dto.Metric{
+					{
 						Untyped: &dto.Untyped{
 							Value: proto.Float64(math.Inf(-1)),
 						},
 					},
-					&dto.Metric{
+					{
 						Label: []*dto.LabelPair{
-							&dto.LabelPair{
+							{
 								Name:  proto.String("name_1"),
 								Value: proto.String("value 1"),
 							},
@@ -156,33 +156,33 @@ untyped_name{name_1="value 1"} -1.23e-45
 				Help: proto.String("summary docstring"),
 				Type: dto.MetricType_SUMMARY.Enum(),
 				Metric: []*dto.Metric{
-					&dto.Metric{
+					{
 						Summary: &dto.Summary{
 							SampleCount: proto.Uint64(42),
 							SampleSum:   proto.Float64(-3.4567),
 							Quantile: []*dto.Quantile{
-								&dto.Quantile{
+								{
 									Quantile: proto.Float64(0.5),
 									Value:    proto.Float64(-1.23),
 								},
-								&dto.Quantile{
+								{
 									Quantile: proto.Float64(0.9),
 									Value:    proto.Float64(.2342354),
 								},
-								&dto.Quantile{
+								{
 									Quantile: proto.Float64(0.99),
 									Value:    proto.Float64(0),
 								},
 							},
 						},
 					},
-					&dto.Metric{
+					{
 						Label: []*dto.LabelPair{
-							&dto.LabelPair{
+							{
 								Name:  proto.String("name_1"),
 								Value: proto.String("value 1"),
 							},
-							&dto.LabelPair{
+							{
 								Name:  proto.String("name_2"),
 								Value: proto.String("value 2"),
 							},
@@ -191,15 +191,15 @@ untyped_name{name_1="value 1"} -1.23e-45
 							SampleCount: proto.Uint64(4711),
 							SampleSum:   proto.Float64(2010.1971),
 							Quantile: []*dto.Quantile{
-								&dto.Quantile{
+								{
 									Quantile: proto.Float64(0.5),
 									Value:    proto.Float64(1),
 								},
-								&dto.Quantile{
+								{
 									Quantile: proto.Float64(0.9),
 									Value:    proto.Float64(2),
 								},
-								&dto.Quantile{
+								{
 									Quantile: proto.Float64(0.99),
 									Value:    proto.Float64(3),
 								},
@@ -229,28 +229,28 @@ summary_name_count{name_1="value 1",name_2="value 2"} 4711
 				Help: proto.String("The response latency."),
 				Type: dto.MetricType_HISTOGRAM.Enum(),
 				Metric: []*dto.Metric{
-					&dto.Metric{
+					{
 						Histogram: &dto.Histogram{
 							SampleCount: proto.Uint64(2693),
 							SampleSum:   proto.Float64(1756047.3),
 							Bucket: []*dto.Bucket{
-								&dto.Bucket{
+								{
 									UpperBound:      proto.Float64(100),
 									CumulativeCount: proto.Uint64(123),
 								},
-								&dto.Bucket{
+								{
 									UpperBound:      proto.Float64(120),
 									CumulativeCount: proto.Uint64(412),
 								},
-								&dto.Bucket{
+								{
 									UpperBound:      proto.Float64(144),
 									CumulativeCount: proto.Uint64(592),
 								},
-								&dto.Bucket{
+								{
 									UpperBound:      proto.Float64(172.8),
 									CumulativeCount: proto.Uint64(1524),
 								},
-								&dto.Bucket{
+								{
 									UpperBound:      proto.Float64(math.Inf(+1)),
 									CumulativeCount: proto.Uint64(2693),
 								},
@@ -277,24 +277,24 @@ request_duration_microseconds_count 2693
 				Help: proto.String("The response latency."),
 				Type: dto.MetricType_HISTOGRAM.Enum(),
 				Metric: []*dto.Metric{
-					&dto.Metric{
+					{
 						Histogram: &dto.Histogram{
 							SampleCount: proto.Uint64(2693),
 							SampleSum:   proto.Float64(1756047.3),
 							Bucket: []*dto.Bucket{
-								&dto.Bucket{
+								{
 									UpperBound:      proto.Float64(100),
 									CumulativeCount: proto.Uint64(123),
 								},
-								&dto.Bucket{
+								{
 									UpperBound:      proto.Float64(120),
 									CumulativeCount: proto.Uint64(412),
 								},
-								&dto.Bucket{
+								{
 									UpperBound:      proto.Float64(144),
 									CumulativeCount: proto.Uint64(592),
 								},
-								&dto.Bucket{
+								{
 									UpperBound:      proto.Float64(172.8),
 									CumulativeCount: proto.Uint64(1524),
 								},
@@ -320,7 +320,7 @@ request_duration_microseconds_count 2693
 				Name: proto.String("name"),
 				Help: proto.String("doc string"),
 				Metric: []*dto.Metric{
-					&dto.Metric{
+					{
 						Counter: &dto.Counter{
 							Value: proto.Float64(math.Inf(-1)),
 						},
@@ -354,7 +354,6 @@ name -Inf
 			)
 		}
 	}
-
 }
 
 func BenchmarkCreate(b *testing.B) {
@@ -363,17 +362,17 @@ func BenchmarkCreate(b *testing.B) {
 		Help: proto.String("The response latency."),
 		Type: dto.MetricType_HISTOGRAM.Enum(),
 		Metric: []*dto.Metric{
-			&dto.Metric{
+			{
 				Label: []*dto.LabelPair{
-					&dto.LabelPair{
+					{
 						Name:  proto.String("name_1"),
 						Value: proto.String("val with\nnew line"),
 					},
-					&dto.LabelPair{
+					{
 						Name:  proto.String("name_2"),
 						Value: proto.String("val with \\backslash and \"quotes\""),
 					},
-					&dto.LabelPair{
+					{
 						Name:  proto.String("name_3"),
 						Value: proto.String("Just a quite long label value to test performance."),
 					},
@@ -382,40 +381,40 @@ func BenchmarkCreate(b *testing.B) {
 					SampleCount: proto.Uint64(2693),
 					SampleSum:   proto.Float64(1756047.3),
 					Bucket: []*dto.Bucket{
-						&dto.Bucket{
+						{
 							UpperBound:      proto.Float64(100),
 							CumulativeCount: proto.Uint64(123),
 						},
-						&dto.Bucket{
+						{
 							UpperBound:      proto.Float64(120),
 							CumulativeCount: proto.Uint64(412),
 						},
-						&dto.Bucket{
+						{
 							UpperBound:      proto.Float64(144),
 							CumulativeCount: proto.Uint64(592),
 						},
-						&dto.Bucket{
+						{
 							UpperBound:      proto.Float64(172.8),
 							CumulativeCount: proto.Uint64(1524),
 						},
-						&dto.Bucket{
+						{
 							UpperBound:      proto.Float64(math.Inf(+1)),
 							CumulativeCount: proto.Uint64(2693),
 						},
 					},
 				},
 			},
-			&dto.Metric{
+			{
 				Label: []*dto.LabelPair{
-					&dto.LabelPair{
+					{
 						Name:  proto.String("name_1"),
 						Value: proto.String("Björn"),
 					},
-					&dto.LabelPair{
+					{
 						Name:  proto.String("name_2"),
 						Value: proto.String("佖佥"),
 					},
-					&dto.LabelPair{
+					{
 						Name:  proto.String("name_3"),
 						Value: proto.String("Just a quite long label value to test performance."),
 					},
@@ -424,19 +423,19 @@ func BenchmarkCreate(b *testing.B) {
 					SampleCount: proto.Uint64(5699),
 					SampleSum:   proto.Float64(49484343543.4343),
 					Bucket: []*dto.Bucket{
-						&dto.Bucket{
+						{
 							UpperBound:      proto.Float64(100),
 							CumulativeCount: proto.Uint64(120),
 						},
-						&dto.Bucket{
+						{
 							UpperBound:      proto.Float64(120),
 							CumulativeCount: proto.Uint64(412),
 						},
-						&dto.Bucket{
+						{
 							UpperBound:      proto.Float64(144),
 							CumulativeCount: proto.Uint64(596),
 						},
-						&dto.Bucket{
+						{
 							UpperBound:      proto.Float64(172.8),
 							CumulativeCount: proto.Uint64(1535),
 						},
@@ -463,17 +462,17 @@ func BenchmarkCreateBuildInfo(b *testing.B) {
 		Help: proto.String("Test the creation of constant 1-value build_info metric."),
 		Type: dto.MetricType_GAUGE.Enum(),
 		Metric: []*dto.Metric{
-			&dto.Metric{
+			{
 				Label: []*dto.LabelPair{
-					&dto.LabelPair{
+					{
 						Name:  proto.String("version"),
 						Value: proto.String("1.2.3"),
 					},
-					&dto.LabelPair{
+					{
 						Name:  proto.String("revision"),
 						Value: proto.String("2e84f5e4eacdffb574035810305191ff390360fe"),
 					},
-					&dto.LabelPair{
+					{
 						Name:  proto.String("go_version"),
 						Value: proto.String("1.11.1"),
 					},
@@ -496,7 +495,7 @@ func BenchmarkCreateBuildInfo(b *testing.B) {
 }
 
 func TestCreateError(t *testing.T) {
-	var scenarios = []struct {
+	scenarios := []struct {
 		in  *dto.MetricFamily
 		err string
 	}{
@@ -516,7 +515,7 @@ func TestCreateError(t *testing.T) {
 				Help: proto.String("doc string"),
 				Type: dto.MetricType_UNTYPED.Enum(),
 				Metric: []*dto.Metric{
-					&dto.Metric{
+					{
 						Untyped: &dto.Untyped{
 							Value: proto.Float64(math.Inf(-1)),
 						},
@@ -532,7 +531,7 @@ func TestCreateError(t *testing.T) {
 				Help: proto.String("doc string"),
 				Type: dto.MetricType_COUNTER.Enum(),
 				Metric: []*dto.Metric{
-					&dto.Metric{
+					{
 						Untyped: &dto.Untyped{
 							Value: proto.Float64(math.Inf(-1)),
 						},
@@ -557,5 +556,4 @@ func TestCreateError(t *testing.T) {
 			)
 		}
 	}
-
 }

--- a/expfmt/text_parse.go
+++ b/expfmt/text_parse.go
@@ -22,9 +22,10 @@ import (
 	"strconv"
 	"strings"
 
+	"google.golang.org/protobuf/proto"
+
 	dto "github.com/prometheus/client_model/go"
 
-	"github.com/golang/protobuf/proto" //nolint:staticcheck // Ignore SA1019. Need to keep deprecated package for compatibility.
 	"github.com/prometheus/common/model"
 )
 

--- a/expfmt/text_parse_test.go
+++ b/expfmt/text_parse_test.go
@@ -19,12 +19,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/golang/protobuf/proto" //nolint:staticcheck // Ignore SA1019. Need to keep deprecated package for compatibility.
+	"google.golang.org/protobuf/proto"
+
 	dto "github.com/prometheus/client_model/go"
 )
 
 func testTextParse(t testing.TB) {
-	var scenarios = []struct {
+	scenarios := []struct {
 		in  string
 		out []*dto.MetricFamily
 	}{
@@ -45,22 +46,22 @@ no_labels{} 3
 # HELP line for non-existing metric will be ignored.
 `,
 			out: []*dto.MetricFamily{
-				&dto.MetricFamily{
+				{
 					Name: proto.String("minimal_metric"),
 					Type: dto.MetricType_UNTYPED.Enum(),
 					Metric: []*dto.Metric{
-						&dto.Metric{
+						{
 							Untyped: &dto.Untyped{
 								Value: proto.Float64(1.234),
 							},
 						},
 					},
 				},
-				&dto.MetricFamily{
+				{
 					Name: proto.String("another_metric"),
 					Type: dto.MetricType_UNTYPED.Enum(),
 					Metric: []*dto.Metric{
-						&dto.Metric{
+						{
 							Untyped: &dto.Untyped{
 								Value: proto.Float64(-3e3),
 							},
@@ -68,11 +69,11 @@ no_labels{} 3
 						},
 					},
 				},
-				&dto.MetricFamily{
+				{
 					Name: proto.String("no_labels"),
 					Type: dto.MetricType_UNTYPED.Enum(),
 					Metric: []*dto.Metric{
-						&dto.Metric{
+						{
 							Untyped: &dto.Untyped{
 								Value: proto.Float64(3),
 							},
@@ -97,18 +98,18 @@ name2{labelname="val2"	,basename   =   "basevalue2"		} +Inf 54321
 name2{ labelname = "val1" , }-Inf
 `,
 			out: []*dto.MetricFamily{
-				&dto.MetricFamily{
+				{
 					Name: proto.String("name"),
 					Help: proto.String("two-line\n doc  str\\ing"),
 					Type: dto.MetricType_COUNTER.Enum(),
 					Metric: []*dto.Metric{
-						&dto.Metric{
+						{
 							Label: []*dto.LabelPair{
-								&dto.LabelPair{
+								{
 									Name:  proto.String("labelname"),
 									Value: proto.String("val1"),
 								},
-								&dto.LabelPair{
+								{
 									Name:  proto.String("basename"),
 									Value: proto.String("basevalue"),
 								},
@@ -117,13 +118,13 @@ name2{ labelname = "val1" , }-Inf
 								Value: proto.Float64(math.NaN()),
 							},
 						},
-						&dto.Metric{
+						{
 							Label: []*dto.LabelPair{
-								&dto.LabelPair{
+								{
 									Name:  proto.String("labelname"),
 									Value: proto.String("val2"),
 								},
-								&dto.LabelPair{
+								{
 									Name:  proto.String("basename"),
 									Value: proto.String("base\"v\\al\nue"),
 								},
@@ -135,18 +136,18 @@ name2{ labelname = "val1" , }-Inf
 						},
 					},
 				},
-				&dto.MetricFamily{
+				{
 					Name: proto.String("name2"),
 					Help: proto.String("doc str\"ing 2"),
 					Type: dto.MetricType_GAUGE.Enum(),
 					Metric: []*dto.Metric{
-						&dto.Metric{
+						{
 							Label: []*dto.LabelPair{
-								&dto.LabelPair{
+								{
 									Name:  proto.String("labelname"),
 									Value: proto.String("val2"),
 								},
-								&dto.LabelPair{
+								{
 									Name:  proto.String("basename"),
 									Value: proto.String("basevalue2"),
 								},
@@ -156,9 +157,9 @@ name2{ labelname = "val1" , }-Inf
 							},
 							TimestampMs: proto.Int64(54321),
 						},
-						&dto.Metric{
+						{
 							Label: []*dto.LabelPair{
-								&dto.LabelPair{
+								{
 									Name:  proto.String("labelname"),
 									Value: proto.String("val1"),
 								},
@@ -197,13 +198,13 @@ my_summary{n1="val3", quantile="0.2"} 4711
 # HELP my_summary 
 `,
 			out: []*dto.MetricFamily{
-				&dto.MetricFamily{
+				{
 					Name: proto.String("fake_sum"),
 					Type: dto.MetricType_UNTYPED.Enum(),
 					Metric: []*dto.Metric{
-						&dto.Metric{
+						{
 							Label: []*dto.LabelPair{
-								&dto.LabelPair{
+								{
 									Name:  proto.String("n1"),
 									Value: proto.String("val1"),
 								},
@@ -214,11 +215,11 @@ my_summary{n1="val3", quantile="0.2"} 4711
 						},
 					},
 				},
-				&dto.MetricFamily{
+				{
 					Name: proto.String("decoy"),
 					Type: dto.MetricType_UNTYPED.Enum(),
 					Metric: []*dto.Metric{
-						&dto.Metric{
+						{
 							Untyped: &dto.Untyped{
 								Value: proto.Float64(-1),
 							},
@@ -226,13 +227,13 @@ my_summary{n1="val3", quantile="0.2"} 4711
 						},
 					},
 				},
-				&dto.MetricFamily{
+				{
 					Name: proto.String("my_summary"),
 					Type: dto.MetricType_SUMMARY.Enum(),
 					Metric: []*dto.Metric{
-						&dto.Metric{
+						{
 							Label: []*dto.LabelPair{
-								&dto.LabelPair{
+								{
 									Name:  proto.String("n1"),
 									Value: proto.String("val1"),
 								},
@@ -241,11 +242,11 @@ my_summary{n1="val3", quantile="0.2"} 4711
 								SampleCount: proto.Uint64(42),
 								SampleSum:   proto.Float64(4711),
 								Quantile: []*dto.Quantile{
-									&dto.Quantile{
+									{
 										Quantile: proto.Float64(0.5),
 										Value:    proto.Float64(110),
 									},
-									&dto.Quantile{
+									{
 										Quantile: proto.Float64(0.9),
 										Value:    proto.Float64(140),
 									},
@@ -253,13 +254,13 @@ my_summary{n1="val3", quantile="0.2"} 4711
 							},
 							TimestampMs: proto.Int64(2),
 						},
-						&dto.Metric{
+						{
 							Label: []*dto.LabelPair{
-								&dto.LabelPair{
+								{
 									Name:  proto.String("n2"),
 									Value: proto.String("val2"),
 								},
-								&dto.LabelPair{
+								{
 									Name:  proto.String("n1"),
 									Value: proto.String("val1"),
 								},
@@ -267,7 +268,7 @@ my_summary{n1="val3", quantile="0.2"} 4711
 							Summary: &dto.Summary{
 								SampleCount: proto.Uint64(5),
 								Quantile: []*dto.Quantile{
-									&dto.Quantile{
+									{
 										Quantile: proto.Float64(-12.34),
 										Value:    proto.Float64(math.NaN()),
 									},
@@ -275,9 +276,9 @@ my_summary{n1="val3", quantile="0.2"} 4711
 							},
 							TimestampMs: proto.Int64(5),
 						},
-						&dto.Metric{
+						{
 							Label: []*dto.LabelPair{
-								&dto.LabelPair{
+								{
 									Name:  proto.String("n1"),
 									Value: proto.String("val2"),
 								},
@@ -287,16 +288,16 @@ my_summary{n1="val3", quantile="0.2"} 4711
 							},
 							TimestampMs: proto.Int64(15),
 						},
-						&dto.Metric{
+						{
 							Label: []*dto.LabelPair{
-								&dto.LabelPair{
+								{
 									Name:  proto.String("n1"),
 									Value: proto.String("val3"),
 								},
 							},
 							Summary: &dto.Summary{
 								Quantile: []*dto.Quantile{
-									&dto.Quantile{
+									{
 										Quantile: proto.Float64(0.2),
 										Value:    proto.Float64(4711),
 									},
@@ -305,17 +306,17 @@ my_summary{n1="val3", quantile="0.2"} 4711
 						},
 					},
 				},
-				&dto.MetricFamily{
+				{
 					Name: proto.String("another_summary"),
 					Type: dto.MetricType_SUMMARY.Enum(),
 					Metric: []*dto.Metric{
-						&dto.Metric{
+						{
 							Label: []*dto.LabelPair{
-								&dto.LabelPair{
+								{
 									Name:  proto.String("n2"),
 									Value: proto.String("val2"),
 								},
-								&dto.LabelPair{
+								{
 									Name:  proto.String("n1"),
 									Value: proto.String("val1"),
 								},
@@ -323,7 +324,7 @@ my_summary{n1="val3", quantile="0.2"} 4711
 							Summary: &dto.Summary{
 								SampleCount: proto.Uint64(20),
 								Quantile: []*dto.Quantile{
-									&dto.Quantile{
+									{
 										Quantile: proto.Float64(0.3),
 										Value:    proto.Float64(-1.2),
 									},
@@ -353,28 +354,28 @@ request_duration_microseconds_count 2693
 					Help: proto.String("The response latency."),
 					Type: dto.MetricType_HISTOGRAM.Enum(),
 					Metric: []*dto.Metric{
-						&dto.Metric{
+						{
 							Histogram: &dto.Histogram{
 								SampleCount: proto.Uint64(2693),
 								SampleSum:   proto.Float64(1756047.3),
 								Bucket: []*dto.Bucket{
-									&dto.Bucket{
+									{
 										UpperBound:      proto.Float64(100),
 										CumulativeCount: proto.Uint64(123),
 									},
-									&dto.Bucket{
+									{
 										UpperBound:      proto.Float64(120),
 										CumulativeCount: proto.Uint64(412),
 									},
-									&dto.Bucket{
+									{
 										UpperBound:      proto.Float64(144),
 										CumulativeCount: proto.Uint64(592),
 									},
-									&dto.Bucket{
+									{
 										UpperBound:      proto.Float64(172.8),
 										CumulativeCount: proto.Uint64(1524),
 									},
-									&dto.Bucket{
+									{
 										UpperBound:      proto.Float64(math.Inf(+1)),
 										CumulativeCount: proto.Uint64(2693),
 									},
@@ -429,7 +430,7 @@ func BenchmarkTextParse(b *testing.B) {
 }
 
 func testTextParseError(t testing.TB) {
-	var scenarios = []struct {
+	scenarios := []struct {
 		in  string
 		err string
 	}{
@@ -656,7 +657,6 @@ metric{quantile="0x1p-3"} 3.14
 			)
 		}
 	}
-
 }
 
 func TestTextParseError(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/prometheus/client_model v0.3.0
 	golang.org/x/net v0.7.0
 	golang.org/x/oauth2 v0.5.0
+	google.golang.org/protobuf v1.28.1
 	gopkg.in/yaml.v2 v2.4.0
 )
 
@@ -31,6 +32,5 @@ require (
 	golang.org/x/sys v0.5.0 // indirect
 	golang.org/x/text v0.7.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
-	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 )


### PR DESCRIPTION
This replaces usage of proto.{Float64,Int32,Int64,String,Uint32,Uint64}, which doesn't break the interface.

And replaces ptypes.TimestampProto by google.golang.org/protobuf/types/known/timestamppb. This works since github.com/golang/protobuf has been bumped to v1.5.2, which makes ptypes.TimestampProto an alias to timestamppb.Timestamp. This is only used test (openmetrics_create_test.go), which won't break interfaces.

Updates: #317

Signed-off-by: Shengjing Zhu <zhsj@debian.org>