### PR TITLE
Change HistogramBucket Boundaries type to int32

### DIFF
--- a/model/value_histogram.go
+++ b/model/value_histogram.go
@@ -43,7 +43,7 @@ func (v *FloatString) UnmarshalJSON(b []byte) error {
 }
 
 type HistogramBucket struct {
-	Boundaries int
+	Boundaries int32
 	Lower      FloatString
 	Upper      FloatString
 	Count      FloatString


### PR DESCRIPTION
Follow up to https://github.com/prometheus/common/pull/417 . Made a mistake earlier, Boundaries is better as int32 for casting to/from compatible protobufs, as protobuf doesn't have int as a format, only int32. Better to correct this earlier to minimise the affected projects.