### PR TITLE
expfmt: only ignore io.EOF errors in TextParse.startOfLine

### DIFF
--- a/expfmt/text_parse.go
+++ b/expfmt/text_parse.go
@@ -142,9 +142,13 @@ func (p *TextParser) reset(in io.Reader) {
 func (p *TextParser) startOfLine() stateFn {
 	p.lineCount++
 	if p.skipBlankTab(); p.err != nil {
-		// End of input reached. This is the only case where
-		// that is not an error but a signal that we are done.
-		p.err = nil
+		// This is the only place that we expect to see io.EOF,
+		// which is not an error but the signal that we are done.
+		// Any other error that happens to align with the start of
+		// a line is still an error.
+		if p.err == io.EOF {
+			p.err = nil
+		}
 		return nil
 	}
 	switch p.currentByte {


### PR DESCRIPTION
We shouldn't ignore all errors here, only `io.EOF`. If an unexpected connection break just happens to align with the start of a new line, that error shouldn't be suppressed.