### PR TITLE
version: add Go build tags to output

### DIFF
--- a/version/info.go
+++ b/version/info.go
@@ -53,6 +53,7 @@ func NewCollector(program string) prometheus.Collector {
 				"goversion": GoVersion,
 				"goos":      GoOS,
 				"goarch":    GoArch,
+				"tags":      getTags(),
 			},
 		},
 		func() float64 { return 1 },
@@ -66,6 +67,7 @@ var versionInfoTmpl = `
   build date:       {{.buildDate}}
   go version:       {{.goVersion}}
   platform:         {{.platform}}
+  tags:             {{.tags}}
 `
 
 // Print returns version information.
@@ -79,6 +81,7 @@ func Print(program string) string {
 		"buildDate": BuildDate,
 		"goVersion": GoVersion,
 		"platform":  GoOS + "/" + GoArch,
+		"tags":      getTags(),
 	}
 	t := template.Must(template.New("version").Parse(versionInfoTmpl))
 
@@ -96,5 +99,5 @@ func Info() string {
 
 // BuildContext returns goVersion, platform, buildUser and buildDate information.
 func BuildContext() string {
-	return fmt.Sprintf("(go=%s, platform=%s, user=%s, date=%s)", GoVersion, GoOS+"/"+GoArch, BuildUser, BuildDate)
+	return fmt.Sprintf("(go=%s, platform=%s, user=%s, date=%s, tags=%s)", GoVersion, GoOS+"/"+GoArch, BuildUser, BuildDate, getTags())
 }

--- a/version/info_default.go
+++ b/version/info_default.go
@@ -19,3 +19,7 @@ package version
 func getRevision() string {
 	return Revision
 }
+
+func getTags() string {
+	return "unknown" // Not available prior to Go 1.18
+}

--- a/version/info_go118.go
+++ b/version/info_go118.go
@@ -19,6 +19,7 @@ package version
 import "runtime/debug"
 
 var computedRevision string
+var computedTags string
 
 func getRevision() string {
 	if Revision != "" {
@@ -27,19 +28,24 @@ func getRevision() string {
 	return computedRevision
 }
 
-func init() {
-	computedRevision = computeRevision()
+func getTags() string {
+	return computedTags
 }
 
-func computeRevision() string {
+func init() {
+	computedRevision, computedTags = computeRevision()
+}
+
+func computeRevision() (string, string) {
 	var (
 		rev      = "unknown"
+		tags     = "unknown"
 		modified bool
 	)
 
 	buildInfo, ok := debug.ReadBuildInfo()
 	if !ok {
-		return rev
+		return rev, tags
 	}
 	for _, v := range buildInfo.Settings {
 		if v.Key == "vcs.revision" {
@@ -50,9 +56,12 @@ func computeRevision() string {
 				modified = true
 			}
 		}
+		if v.Key == "-tags" {
+			tags = v.Value
+		}
 	}
 	if modified {
-		return rev + "-modified"
+		return rev + "-modified", tags
 	}
-	return rev
+	return rev, tags
 }


### PR DESCRIPTION
Build tags allow different implementations of code sections to be included in the binary, so can be important to understand the exact behaviour expected at runtime.

This change includes build tags at the end of the `BuildContext` string, and as an extra label on the info metric.

Example output when linked into Prometheus:
```
ts=2023-02-24T11:33:59.355Z caller=main.go:561 level=info build_context="(go=go1.19.3, platform=linux/amd64, user=vagrant@vagrant, date=20230224-11:12:08, tags=netgo,builtinassets,stringlabels)"
```