### PR TITLE
Add DSCP value to outgoing HTTP requests

### DIFF
--- a/config/http_config_test.go
+++ b/config/http_config_test.go
@@ -1838,3 +1838,14 @@ no_proxy: promcon.io,cncf.io`, proxyServer.URL),
 		})
 	}
 }
+
+func TestDSCPDialContext(t *testing.T) {
+	cfg := HTTPClientConfig{DSCP: 46}
+	dialer := &DSCPDialer{DSCP: cfg.DSCP}
+	httpClientOption := WithDialContextFunc(dialer.DialContext)
+
+	_, err := NewClientFromConfig(cfg, "test", httpClientOption)
+	if err != nil {
+		t.Fatalf("Can't create a client from this config: %+v", cfg)
+	}
+}


### PR DESCRIPTION
Add ability to specify a DSCP value in IPv4/IPv6 header of outgoing HTTP requests

