### PR TITLE
Allow custom log.Logger

### DIFF
--- a/promlog/log.go
+++ b/promlog/log.go
@@ -112,10 +112,10 @@ type Config struct {
 // with a timestamp. The output always goes to stderr.
 func New(config *Config) log.Logger {
 	if config.Format != nil && config.Format.s == "json" {
-		return NewWithLogger(log.NewJSONLogger(os.Stderr), config)
-	} else {
-		return NewWithLogger(log.NewLogfmtLogger(os.Stderr), config)
+		return NewWithLogger(log.NewJSONLogger(log.NewSyncWriter(os.Stderr)), config)
 	}
+
+	return NewWithLogger(log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr)), config)
 }
 
 // NewWithLogger returns a new leveled oklog logger with a custom log.Logger.
@@ -135,10 +135,10 @@ func NewWithLogger(l log.Logger, config *Config) log.Logger {
 // changed, like the level.
 func NewDynamic(config *Config) *logger {
 	if config.Format != nil && config.Format.s == "json" {
-		return NewDynamicWithLogger(log.NewJSONLogger(os.Stderr), config)
-	} else {
-		return NewDynamicWithLogger(log.NewLogfmtLogger(os.Stderr), config)
+		return NewDynamicWithLogger(log.NewJSONLogger(log.NewSyncWriter(os.Stderr)), config)
 	}
+
+	return NewDynamicWithLogger(log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr)), config)
 }
 
 // NewDynamicWithLogger returns a new leveled logger with a custom io.Writer.

--- a/promlog/log.go
+++ b/promlog/log.go
@@ -111,13 +111,16 @@ type Config struct {
 // New returns a new leveled oklog logger. Each logged line will be annotated
 // with a timestamp. The output always goes to stderr.
 func New(config *Config) log.Logger {
-	var l log.Logger
 	if config.Format != nil && config.Format.s == "json" {
-		l = log.NewJSONLogger(log.NewSyncWriter(os.Stderr))
+		return NewWithLogger(log.NewJSONLogger(os.Stderr), config)
 	} else {
-		l = log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
+		return NewWithLogger(log.NewLogfmtLogger(os.Stderr), config)
 	}
+}
 
+// NewWithLogger returns a new leveled oklog logger with a custom log.Logger.
+// Each logged line will be annotated with a timestamp.
+func NewWithLogger(l log.Logger, config *Config) log.Logger {
 	if config.Level != nil {
 		l = log.With(l, "ts", timestampFormat, "caller", log.Caller(5))
 		l = level.NewFilter(l, config.Level.o)
@@ -131,13 +134,17 @@ func New(config *Config) log.Logger {
 // with a timestamp. The output always goes to stderr. Some properties can be
 // changed, like the level.
 func NewDynamic(config *Config) *logger {
-	var l log.Logger
 	if config.Format != nil && config.Format.s == "json" {
-		l = log.NewJSONLogger(log.NewSyncWriter(os.Stderr))
+		return NewDynamicWithLogger(log.NewJSONLogger(os.Stderr), config)
 	} else {
-		l = log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
+		return NewDynamicWithLogger(log.NewLogfmtLogger(os.Stderr), config)
 	}
+}
 
+// NewDynamicWithLogger returns a new leveled logger with a custom io.Writer.
+// Each logged line will be annotated with a timestamp.
+// Some properties can be changed, like the level.
+func NewDynamicWithLogger(l log.Logger, config *Config) *logger {
 	lo := &logger{
 		base:    l,
 		leveled: l,


### PR DESCRIPTION
This PR allow to use custom log.Logger together with the promlog wrapper mechanics and can be considered as alternative to copy, own and manually patch as needed.

A potential use case is using promlog with an Windows Event Log backend. 

* https://github.com/go-kit/log/pull/31

---

Not sure, if you are willing to include Windows EventLog support by default.