### PR TITLE
config: allow exposing real secret value through marshal

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -27,8 +27,16 @@ const secretToken = "<secret>"
 // Secret special type for storing secrets.
 type Secret string
 
+// MarshalSecretValue if set to true will expose Secret type
+// through the marshal interfaces. Useful for outside projects
+// that load and marshal the Prometheus config.
+var MarshalSecretValue bool = false
+
 // MarshalYAML implements the yaml.Marshaler interface for Secrets.
 func (s Secret) MarshalYAML() (interface{}, error) {
+	if MarshalSecretValue {
+		return string(s), nil
+	}
 	if s != "" {
 		return secretToken, nil
 	}
@@ -43,6 +51,9 @@ func (s *Secret) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 // MarshalJSON implements the json.Marshaler interface for Secret.
 func (s Secret) MarshalJSON() ([]byte, error) {
+	if MarshalSecretValue {
+		return json.Marshal(string(s))
+	}
 	if len(s) == 0 {
 		return json.Marshal("")
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -28,9 +28,11 @@ func TestJSONMarshalSecret(t *testing.T) {
 		S Secret
 	}
 	for _, tc := range []struct {
-		desc     string
-		data     tmp
-		expected string
+		desc      string
+		data      tmp
+		expected  string
+		trueValue bool
+		testYAML  bool
 	}{
 		{
 			desc: "inhabited",
@@ -40,13 +42,35 @@ func TestJSONMarshalSecret(t *testing.T) {
 			expected: "{\"S\":\"\\u003csecret\\u003e\"}",
 		},
 		{
+			desc:      "true value in JSON",
+			data:      tmp{"test"},
+			expected:  `{"S":"test"}`,
+			trueValue: true,
+		},
+		{
+			desc: "true value in YAML",
+			data: tmp{"test"},
+			expected: `s: test
+`,
+			trueValue: true,
+			testYAML:  true,
+		},
+		{
 			desc:     "empty",
 			data:     tmp{},
 			expected: "{\"S\":\"\"}",
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			c, err := json.Marshal(tc.data)
+			MarshalSecretValue = tc.trueValue
+
+			var marshalFN func(any) ([]byte, error)
+			if tc.testYAML {
+				marshalFN = yaml.Marshal
+			} else {
+				marshalFN = json.Marshal
+			}
+			c, err := marshalFN(tc.data)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
There are external projects out there that marshal/unmarshal the Prometheus config that has secrets. To get the real value currently such horrible workarounds are in place:
https://github.com/tkestack/kvass/blob/master/pkg/sidecar/injector.go#L175-L214

Let's add a way to get the original values through the `Secret` type to avoid such things.