### PR TITLE
Add read-only token permissions

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -10,6 +10,9 @@ on:
       - ".golangci.yml"
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   golangci:
     name: lint


### PR DESCRIPTION
Fixes https://github.com/prometheus/prometheus/issues/12379.

As mentioned there, this PR ensures the golangci-lint workflow always runs with read-only permissions, protecting the projects that use it from supply-chain attacks.

This PR was originally submitted as https://github.com/prometheus/procfs/pull/525, but following @discordianfish's suggestion there, I'm re-submitting it here.