### PR TITLE
Add Sigv4 Endpoint config parameter

### DIFF
--- a/sigv4/sigv4.go
+++ b/sigv4/sigv4.go
@@ -62,6 +62,7 @@ func NewSigV4RoundTripper(cfg *SigV4Config, next http.RoundTripper) (http.RoundT
 	sess, err := session.NewSessionWithOptions(session.Options{
 		Config: aws.Config{
 			Region:      aws.String(cfg.Region),
+			Endpoint:    aws.String(cfg.Endpoint),
 			Credentials: creds,
 		},
 		Profile: cfg.Profile,

--- a/sigv4/sigv4_config.go
+++ b/sigv4/sigv4_config.go
@@ -28,6 +28,7 @@ type SigV4Config struct {
 	SecretKey config.Secret `yaml:"secret_key,omitempty"`
 	Profile   string        `yaml:"profile,omitempty"`
 	RoleARN   string        `yaml:"role_arn,omitempty"`
+	Endpoint  string        `yaml:"endpoint,omitempty"`
 }
 
 func (c *SigV4Config) Validate() error {

--- a/sigv4/testdata/sigv4_good.yaml
+++ b/sigv4/testdata/sigv4_good.yaml
@@ -3,3 +3,4 @@ access_key: AccessKey
 secret_key: SecretKey
 profile: profile
 role_arn: blah:role/arn
+endpoint: https://sts.us-west-2.amazonaws.com


### PR DESCRIPTION
Exposes an `endpoint` field in the sigv4 config, so that the call to STS when assuming a role with a web identity can use a custom STS endpoint, e.g. a VPC endpoint.

No clients other than the STS one are made from the session config here, so setting `Endpoint` should be safe, but it can also be a resolver if this is a concern.

Addresses https://github.com/prometheus/prometheus/issues/11710.