### PR TITLE
Write created lines when negotiating OpenMetrics

### DIFF
--- a/expfmt/encode.go
+++ b/expfmt/encode.go
@@ -139,7 +139,13 @@ func NegotiateIncludingOpenMetrics(h http.Header) Format {
 // interface is kept for backwards compatibility.
 // In cases where the Format does not allow for UTF-8 names, the global
 // NameEscapingScheme will be applied.
-func NewEncoder(w io.Writer, format Format) Encoder {
+//
+// NewEncoder can be called with additional options to customize the OpenMetrics text output.
+// For example:
+// NewEncoder(w, FmtOpenMetrics_1_0_0, WithCreatedLines())
+//
+// Extra options are ignored for all other formats.
+func NewEncoder(w io.Writer, format Format, options ...EncoderOption) Encoder {
 	escapingScheme := format.ToEscapingScheme()
 
 	switch format.FormatType() {
@@ -178,7 +184,7 @@ func NewEncoder(w io.Writer, format Format) Encoder {
 	case TypeOpenMetrics:
 		return encoderCloser{
 			encode: func(v *dto.MetricFamily) error {
-				_, err := MetricFamilyToOpenMetrics(w, model.EscapeMetricFamily(v, escapingScheme))
+				_, err := MetricFamilyToOpenMetrics(w, model.EscapeMetricFamily(v, escapingScheme), options...)
 				return err
 			},
 			close: func() error {

--- a/expfmt/openmetrics_create.go
+++ b/expfmt/openmetrics_create.go
@@ -541,11 +541,10 @@ func writeOpenMetricsCreated(w enhancedWriter,
 		return written, err
 	}
 
-	ts := createdTimestamp.AsTime()
 	// TODO(beorn7): Format this directly from components of ts to
 	// avoid overflow/underflow and precision issues of the float
 	// conversion.
-	n, err = writeOpenMetricsFloat(w, float64(ts.UnixNano())/1e9)
+	n, err = writeOpenMetricsFloat(w, float64(createdTimestamp.AsTime().UnixNano())/1e9)
 	written += n
 	if err != nil {
 		return written, err

--- a/expfmt/openmetrics_create.go
+++ b/expfmt/openmetrics_create.go
@@ -22,8 +22,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/prometheus/common/model"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/prometheus/common/model"
 
 	dto "github.com/prometheus/client_model/go"
 )

--- a/expfmt/openmetrics_create_test.go
+++ b/expfmt/openmetrics_create_test.go
@@ -551,7 +551,7 @@ foos_created 12345.6
 				Help: proto.String("Number of foos."),
 				Type: dto.MetricType_COUNTER.Enum(),
 				Metric: []*dto.Metric{
-					&dto.Metric{
+					{
 						Counter: &dto.Counter{
 							Value:            proto.Float64(42),
 							CreatedTimestamp: openMetricsTimestamp,

--- a/expfmt/openmetrics_create_test.go
+++ b/expfmt/openmetrics_create_test.go
@@ -42,7 +42,7 @@ func TestCreateOpenMetrics(t *testing.T) {
 
 	scenarios := []struct {
 		in      *dto.MetricFamily
-		options []ToOpenMetricsOption
+		options []EncoderOption
 		out     string
 	}{
 		// 0: Counter, timestamp given, no _total suffix.
@@ -343,7 +343,7 @@ unknown_name{name_1="value 1"} -1.23e-45
 					},
 				},
 			},
-			options: []ToOpenMetricsOption{WithCreatedLines()},
+			options: []EncoderOption{WithCreatedLines()},
 			out: `# HELP summary_name summary docstring
 # TYPE summary_name summary
 summary_name{quantile="0.5"} -1.23
@@ -398,7 +398,7 @@ summary_name_created{name_1="value 1",name_2="value 2"} 12345.6
 					},
 				},
 			},
-			options: []ToOpenMetricsOption{WithCreatedLines()},
+			options: []EncoderOption{WithCreatedLines()},
 			out: `# HELP request_duration_microseconds The response latency.
 # TYPE request_duration_microseconds histogram
 request_duration_microseconds_bucket{le="100.0"} 123
@@ -537,7 +537,7 @@ request_duration_microseconds_count 2693
 					},
 				},
 			},
-			options: []ToOpenMetricsOption{WithCreatedLines()},
+			options: []EncoderOption{WithCreatedLines()},
 			out: `# HELP foos Number of foos.
 # TYPE foos counter
 foos_total 42.0


### PR DESCRIPTION
Following up on the [Design doc](https://docs.google.com/document/d/1kakDVn8aP1JerimLeazuMfy2jaB14W2kZDHMRokPcv4/edit), this PR aims to implement writing created timestamps when using OpenMetrics.