### PR TITLE
Support environment variables for LOG_LEVEL and LOG_FORMAT

### DIFF
--- a/promlog/flag/flag.go
+++ b/promlog/flag/flag.go
@@ -37,9 +37,11 @@ const FormatFlagHelp = "Output format of log messages. One of: [logfmt, json]"
 func AddFlags(a *kingpin.Application, config *promlog.Config) {
 	config.Level = &promlog.AllowedLevel{}
 	a.Flag(LevelFlagName, LevelFlagHelp).
+		Envar("LOG_LEVEL").
 		Default("info").SetValue(config.Level)
 
 	config.Format = &promlog.AllowedFormat{}
 	a.Flag(FormatFlagName, FormatFlagHelp).
+		Envar("LOG_FORMAT").
 		Default("logfmt").SetValue(config.Format)
 }


### PR DESCRIPTION
Added Envars for log level and log format to support reading from environment variables.
Useful when running exporter within docker container such as Oracle exporter.
Related issue: https://github.com/iamseth/oracledb_exporter/issues/342