### PR TITLE
http_config: Add host

### DIFF
--- a/config/http_config.go
+++ b/config/http_config.go
@@ -311,7 +311,7 @@ type HTTPClientConfig struct {
 	EnableHTTP2 bool `yaml:"enable_http2" json:"enable_http2"`
 	// Host optionally overrides the Host header to send.
 	// If empty, the host from the URL will be used.
-	Host string `yaml:"host" json:"host"`
+	Host string `yaml:"host,omitempty" json:"host,omitempty"`
 	// Proxy configuration.
 	ProxyConfig `yaml:",inline"`
 }

--- a/config/http_config_test.go
+++ b/config/http_config_test.go
@@ -35,7 +35,7 @@ import (
 	"testing"
 	"time"
 
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 )
 
 const (
@@ -1498,6 +1498,32 @@ func TestOAuth2UserAgent(t *testing.T) {
 	authorization := resp.Request.Header.Get("Authorization")
 	if authorization != "Bearer 12345" {
 		t.Fatalf("Expected authorization header to be 'Bearer 12345', got '%s'", authorization)
+	}
+}
+
+func TestHost(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Host != "localhost.localdomain" {
+			t.Fatalf("Expected Host header in request to be 'localhost.localdomain', got '%s'", r.Host)
+		}
+
+		w.Header().Add("Content-Type", "application/json")
+	}))
+	defer ts.Close()
+
+	config := DefaultHTTPClientConfig
+
+	rt, err := NewRoundTripperFromConfig(config, "test_host", WithHost("localhost.localdomain"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client := http.Client{
+		Transport: rt,
+	}
+	_, err = client.Get(ts.URL)
+	if err != nil {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
Follow-up: https://github.com/prometheus/prometheus/pull/13157

Host allows to override the hostname from URL. This can be useful if DNS is not stable but the endpoint required an valid host.