### PR TITLE
Make version getRevision public

### DIFF
--- a/version/info.go
+++ b/version/info.go
@@ -48,7 +48,7 @@ func NewCollector(program string) prometheus.Collector {
 			),
 			ConstLabels: prometheus.Labels{
 				"version":   Version,
-				"revision":  getRevision(),
+				"revision":  GetRevision(),
 				"branch":    Branch,
 				"goversion": GoVersion,
 				"goos":      GoOS,
@@ -75,7 +75,7 @@ func Print(program string) string {
 	m := map[string]string{
 		"program":   program,
 		"version":   Version,
-		"revision":  getRevision(),
+		"revision":  GetRevision(),
 		"branch":    Branch,
 		"buildUser": BuildUser,
 		"buildDate": BuildDate,
@@ -94,7 +94,7 @@ func Print(program string) string {
 
 // Info returns version, branch and revision information.
 func Info() string {
-	return fmt.Sprintf("(version=%s, branch=%s, revision=%s)", Version, Branch, getRevision())
+	return fmt.Sprintf("(version=%s, branch=%s, revision=%s)", Version, Branch, GetRevision())
 }
 
 // BuildContext returns goVersion, platform, buildUser and buildDate information.

--- a/version/info_default.go
+++ b/version/info_default.go
@@ -16,7 +16,7 @@
 
 package version
 
-func getRevision() string {
+func GetRevision() string {
 	return Revision
 }
 

--- a/version/info_go118.go
+++ b/version/info_go118.go
@@ -21,7 +21,7 @@ import "runtime/debug"
 var computedRevision string
 var computedTags string
 
-func getRevision() string {
+func GetRevision() string {
 	if Revision != "" {
 		return Revision
 	}


### PR DESCRIPTION
Make version package `getRevision()` a public function to allow implementing `NewCollector()` outside of the version package easier.