### PR TITLE
version: make GetTegs() public

### DIFF
--- a/version/info.go
+++ b/version/info.go
@@ -53,7 +53,7 @@ func NewCollector(program string) prometheus.Collector {
 				"goversion": GoVersion,
 				"goos":      GoOS,
 				"goarch":    GoArch,
-				"tags":      getTags(),
+				"tags":      GetTags(),
 			},
 		},
 		func() float64 { return 1 },
@@ -81,7 +81,7 @@ func Print(program string) string {
 		"buildDate": BuildDate,
 		"goVersion": GoVersion,
 		"platform":  GoOS + "/" + GoArch,
-		"tags":      getTags(),
+		"tags":      GetTags(),
 	}
 	t := template.Must(template.New("version").Parse(versionInfoTmpl))
 
@@ -99,5 +99,5 @@ func Info() string {
 
 // BuildContext returns goVersion, platform, buildUser and buildDate information.
 func BuildContext() string {
-	return fmt.Sprintf("(go=%s, platform=%s, user=%s, date=%s, tags=%s)", GoVersion, GoOS+"/"+GoArch, BuildUser, BuildDate, getTags())
+	return fmt.Sprintf("(go=%s, platform=%s, user=%s, date=%s, tags=%s)", GoVersion, GoOS+"/"+GoArch, BuildUser, BuildDate, GetTags())
 }

--- a/version/info_go118.go
+++ b/version/info_go118.go
@@ -30,7 +30,7 @@ func GetRevision() string {
 	return computedRevision
 }
 
-func getTags() string {
+func GetTags() string {
 	return computedTags
 }
 


### PR DESCRIPTION
So it can be used by external collectors

I think it was forgotten in #563 @SuperQ @bwplotka @kakkoyun 