### PR TITLE
extfmt: allow trailing spaces

### DIFF
--- a/expfmt/text_parse.go
+++ b/expfmt/text_parse.go
@@ -478,6 +478,9 @@ func (p *TextParser) startTimestamp() stateFn {
 	if p.readTokenUntilWhitespace(); p.err != nil {
 		return nil // Unexpected end of input.
 	}
+	if p.currentToken.String() == "" {
+		return p.startOfLine
+	}
 	timestamp, err := strconv.ParseInt(p.currentToken.String(), 10, 64)
 	if err != nil {
 		// Create a more helpful error message.
@@ -488,7 +491,7 @@ func (p *TextParser) startTimestamp() stateFn {
 	if p.readTokenUntilNewline(false); p.err != nil {
 		return nil // Unexpected end of input.
 	}
-	if p.currentToken.Len() > 0 {
+	if strings.TrimSpace(p.currentToken.String()) != "" {
 		p.parseError(fmt.Sprintf("spurious string after timestamp: %q", p.currentToken.String()))
 		return nil
 	}
@@ -521,7 +524,7 @@ func (p *TextParser) readingType() stateFn {
 	if p.readTokenUntilNewline(false); p.err != nil {
 		return nil // Unexpected end of input.
 	}
-	metricType, ok := dto.MetricType_value[strings.ToUpper(p.currentToken.String())]
+	metricType, ok := dto.MetricType_value[strings.ToUpper(strings.TrimSpace(p.currentToken.String()))]
 	if !ok {
 		p.parseError(fmt.Sprintf("unknown metric type %q", p.currentToken.String()))
 		return nil

--- a/expfmt/text_parse_test.go
+++ b/expfmt/text_parse_test.go
@@ -385,6 +385,45 @@ request_duration_microseconds_count 2693
 				},
 			},
 		},
+		// 5: Trailing white space in TYPE declaration.
+		{
+			in: `
+# TYPE name counter 
+name {labelname="val1"} 1 
+name {labelname="val2"} 0.23 1234567890 
+`,
+			out: []*dto.MetricFamily{
+				{
+					Name: proto.String("name"),
+					Type: dto.MetricType_COUNTER.Enum(),
+					Metric: []*dto.Metric{
+						{
+							Label: []*dto.LabelPair{
+								{
+									Name:  proto.String("labelname"),
+									Value: proto.String("val1"),
+								},
+							},
+							Counter: &dto.Counter{
+								Value: proto.Float64(1),
+							},
+						},
+						{
+							Label: []*dto.LabelPair{
+								{
+									Name:  proto.String("labelname"),
+									Value: proto.String("val2"),
+								},
+							},
+							Counter: &dto.Counter{
+								Value: proto.Float64(0.23),
+							},
+							TimestampMs: proto.Int64(1234567890),
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for i, scenario := range scenarios {


### PR DESCRIPTION
There is no confuse even if we allow trailing white spaces, so I allowed trailing white spaces in Prometheus text files.

It might be better to validate trailing white spaces in linter, but we can't do this with current implementation.
