### PR TITLE
Avoid off-spec openmetrics exposition when exemplars have empty labels

### DIFF
--- a/expfmt/openmetrics_create.go
+++ b/expfmt/openmetrics_create.go
@@ -350,7 +350,7 @@ func writeOpenMetricsSample(
 			return written, err
 		}
 	}
-	if exemplar != nil {
+	if exemplar != nil && len(exemplar.Label) > 0 {
 		n, err = writeExemplar(w, exemplar)
 		written += n
 		if err != nil {

--- a/expfmt/openmetrics_create_test.go
+++ b/expfmt/openmetrics_create_test.go
@@ -419,6 +419,31 @@ foos_total 42.0
 # TYPE name counter
 `,
 		},
+		// 9: Simple Counter with exemplar that has empty label set:
+		// ignore the exemplar, since OpenMetrics spec requires labels.
+		{
+			in: &dto.MetricFamily{
+				Name: proto.String("foos_total"),
+				Help: proto.String("Number of foos."),
+				Type: dto.MetricType_COUNTER.Enum(),
+				Metric: []*dto.Metric{
+					{
+						Counter: &dto.Counter{
+							Value: proto.Float64(42),
+							Exemplar: &dto.Exemplar{
+								Label:     []*dto.LabelPair{},
+								Value:     proto.Float64(1),
+								Timestamp: openMetricsTimestamp,
+							},
+						},
+					},
+				},
+			},
+			out: `# HELP foos Number of foos.
+# TYPE foos counter
+foos_total 42.0
+`,
+		},
 	}
 
 	for i, scenario := range scenarios {


### PR DESCRIPTION
Will fix https://github.com/prometheus/client_golang/issues/1333

`client_golang` currently allows creating exemplars with an empty label set, and they get rendered like:

```
...
foos_total 42.0 #  1.0 12345.6
...
```

(Note the double space after the exemplar's opening `#`)

Based on the [current text of the specification](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#text-format), the openmetrics text format effectively requires one label – so it seems best to just ignore the exemplars.

