### PR TITLE
Deprecate version.NewCollector

### DIFF
--- a/version/info.go
+++ b/version/info.go
@@ -35,6 +35,8 @@ var (
 	GoArch    = runtime.GOARCH
 )
 
+// Deprecated: Use github.com/prometheus/client_golang/prometheus/collectors/version.NewCollector instead.
+//
 // NewCollector returns a collector that exports metrics about current version
 // information.
 func NewCollector(program string) prometheus.Collector {


### PR DESCRIPTION
Mark the version.NewCollector function deprecated in favor of the new version collector package in github.com/prometheus/client_golang. This will allow us to break the circular dependency between the two repos.