### PR TITLE
Remove deprecated version function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f
-	github.com/prometheus/client_golang v1.19.0
 	github.com/prometheus/client_model v0.6.0
 	golang.org/x/net v0.21.0
 	golang.org/x/oauth2 v0.17.0
@@ -23,6 +22,7 @@ require (
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/jpillora/backoff v1.0.0 // indirect
+	github.com/prometheus/client_golang v1.19.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/rogpeppe/go-internal v1.10.0 // indirect
 	github.com/xhit/go-str2duration/v2 v2.1.0 // indirect

--- a/version/info.go
+++ b/version/info.go
@@ -19,8 +19,6 @@ import (
 	"runtime"
 	"strings"
 	"text/template"
-
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 // Build information. Populated at build-time.
@@ -34,33 +32,6 @@ var (
 	GoOS      = runtime.GOOS
 	GoArch    = runtime.GOARCH
 )
-
-// Deprecated: Use github.com/prometheus/client_golang/prometheus/collectors/version.NewCollector instead.
-//
-// NewCollector returns a collector that exports metrics about current version
-// information.
-func NewCollector(program string) prometheus.Collector {
-	return prometheus.NewGaugeFunc(
-		prometheus.GaugeOpts{
-			Namespace: program,
-			Name:      "build_info",
-			Help: fmt.Sprintf(
-				"A metric with a constant '1' value labeled by version, revision, branch, goversion from which %s was built, and the goos and goarch for the build.",
-				program,
-			),
-			ConstLabels: prometheus.Labels{
-				"version":   Version,
-				"revision":  GetRevision(),
-				"branch":    Branch,
-				"goversion": GoVersion,
-				"goos":      GoOS,
-				"goarch":    GoArch,
-				"tags":      GetTags(),
-			},
-		},
-		func() float64 { return 1 },
-	)
-}
 
 // versionInfoTmpl contains the template used by Info.
 var versionInfoTmpl = `


### PR DESCRIPTION
Remove deprecated version.NewCollector function. This has been moved to `github.com/prometheus/client_golang`. This fixes the circular dependency between the two repos.