### PR TITLE
Remove unused 'Host' member from HTTPClientConfig

### DIFF
--- a/config/http_config.go
+++ b/config/http_config.go
@@ -309,9 +309,6 @@ type HTTPClientConfig struct {
 	// The omitempty flag is not set, because it would be hidden from the
 	// marshalled configuration when set to false.
 	EnableHTTP2 bool `yaml:"enable_http2" json:"enable_http2"`
-	// Host optionally overrides the Host header to send.
-	// If empty, the host from the URL will be used.
-	Host string `yaml:"host,omitempty" json:"host,omitempty"`
 	// Proxy configuration.
 	ProxyConfig `yaml:",inline"`
 }


### PR DESCRIPTION
Doesn't seem to be used, and it breaks Prometheus Docker SD which also has a `host` field defined in Yaml.

Added in #549