### PR TITLE
Retract v0.50.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,3 +31,5 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 )
+
+retract v0.50.0 // Critical bug in counter suffixes, please read issue https://github.com/prometheus/common/issues/605


### PR DESCRIPTION
Mark the v0.50.0 tag as retracted in the Go modules due to the critical nature of the issue.