### PR TITLE
LabelSet.String: restore faster sort call

### DIFF
--- a/model/labelset_string.go
+++ b/model/labelset_string.go
@@ -17,7 +17,7 @@ package model
 
 import (
 	"bytes"
-	"sort"
+	"slices"
 	"strconv"
 )
 
@@ -28,7 +28,7 @@ func (l LabelSet) String() string {
 	for name := range l {
 		labelNames = append(labelNames, string(name))
 	}
-	sort.Strings(labelNames)
+	slices.Sort(labelNames)
 	var bytea [1024]byte // On stack to avoid memory allocation while building the output.
 	b := bytes.NewBuffer(bytea[:0])
 	b.WriteByte('{')


### PR DESCRIPTION
This was changed without explanation at #617; let's put it back.

```
goos: darwin
goarch: arm64
pkg: github.com/prometheus/common/model
                       │ before.txt  │             after.txt              │
                       │   sec/op    │   sec/op     vs base               │
LabelSetStringMethod-8   500.4n ± 0%   434.4n ± 0%  -13.19% (p=0.002 n=6)

                       │ before.txt  │             after.txt             │
                       │    B/op     │    B/op     vs base               │
LabelSetStringMethod-8   616.00 ± 0%   80.00 ± 0%  -87.01% (p=0.002 n=6)

                       │ before.txt │             after.txt             │
                       │ allocs/op  │ allocs/op   vs base               │
LabelSetStringMethod-8   3.000 ± 0%   1.000 ± 0%  -66.67% (p=0.002 n=6)
```