### PR TITLE
LabelSet: add unit test for String method

### DIFF
--- a/model/labelset_test.go
+++ b/model/labelset_test.go
@@ -123,6 +123,38 @@ func TestLabelSetMerge(t *testing.T) {
 	}
 }
 
+func TestLabelSet_String(t *testing.T) {
+	tests := []struct {
+		input LabelSet
+		want  string
+	}{
+		{
+			input: nil,
+			want:  `{}`,
+		}, {
+			input: LabelSet{
+				"foo": "bar",
+			},
+			want: `{foo="bar"}`,
+		}, {
+			input: LabelSet{
+				"foo":   "bar",
+				"foo2":  "bar",
+				"abc":   "prometheus",
+				"foo11": "bar11",
+			},
+			want: `{abc="prometheus", foo="bar", foo11="bar11", foo2="bar"}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run("test", func(t *testing.T) {
+			if got := tt.input.String(); got != tt.want {
+				t.Errorf("LabelSet.String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 // Benchmark Results for LabelSet's String() method
 // ---------------------------------------------------------------------------------------------------------
 // goos: linux


### PR DESCRIPTION
It was tested as part of `TestUnmarshalJSONLabelSet`, but let's have it explicit.
