### PR TITLE
enable errcheck linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,20 +1,20 @@
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
 linters:
   enable:
+    - errcheck
     - errorlint
     - gofumpt
     - goimports
+    - gosimple
+    - govet
+    - ineffassign
     - misspell
     - revive
+    - staticcheck
     - testifylint
-
-issues:
-  exclude-rules:
-    - path: _test.go
-      linters:
-        - errcheck
-  max-issues-per-linter: 0
-  max-same-issues: 0
-
+    - unused
 linters-settings:
   goimports:
     local-prefixes: github.com/prometheus/common


### PR DESCRIPTION
* Sort golangci-lint configuration properties
* Enable errcheck linter
* Explicitly list already used linters