### PR TITLE
Don't always fetch a OAuth2 token, if the secret from a file didn't change

### DIFF
--- a/config/http_config.go
+++ b/config/http_config.go
@@ -964,7 +964,7 @@ func (rt *oauth2RoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 			}
 
 			rt.mtx.Lock()
-			rt.lastSecret = secret
+			rt.lastSecret = newSecret
 			rt.lastRT.Source = source
 			if rt.client != nil {
 				rt.client.CloseIdleConnections()

--- a/config/http_config_test.go
+++ b/config/http_config_test.go
@@ -1630,7 +1630,8 @@ endpoint_params:
 		t.Fatalf("Got unmarshalled config %v, expected %v", unmarshalledConfig, expectedConfig)
 	}
 
-	rt := NewOAuth2RoundTripper(NewInlineSecret(string(expectedConfig.ClientSecret)), &expectedConfig, http.DefaultTransport, &defaultHTTPClientOptions)
+	secret := NewInlineSecret(string(expectedConfig.ClientSecret))
+	rt := NewOAuth2RoundTripper(secret, &expectedConfig, http.DefaultTransport, &defaultHTTPClientOptions)
 
 	client := http.Client{
 		Transport: rt,
@@ -1800,7 +1801,8 @@ endpoint_params:
 		t.Fatalf("Got unmarshalled config %v, expected %v", unmarshalledConfig, expectedConfig)
 	}
 
-	rt := NewOAuth2RoundTripper(NewInlineSecret(string(expectedConfig.ClientSecret)), &expectedConfig, http.DefaultTransport, &defaultHTTPClientOptions)
+	secret := NewFileSecret(expectedConfig.ClientSecretFile)
+	rt := NewOAuth2RoundTripper(secret, &expectedConfig, http.DefaultTransport, &defaultHTTPClientOptions)
 
 	client := http.Client{
 		Transport: rt,


### PR DESCRIPTION
When configuring a OAuth2 client using the `client_secret_file` configuration option, the original intent of the code was to *not* forcefully refetch a token if the content of the file didn't change.

However, both the test and the implementation had 2 typos and a new token token was fetched on every request through the HTTP client:

* The code was always keeping track of the very first `secret` configured ; in the case of a secret coming from a file, the secret kept in the state was always empty and would never match the content of the file (except if the file contains nothing, in which case the authentication couldn't proceed anyway).
* The test for this feature was using an inline secret which was never changing, instead of the intended secret file. Thus, as the secret was never changed, the token endpoint was never called.

I extracted the secret variable from the tests to make it, hopefully, a bit clearer to see it's actual type.