### PR TITLE
Expose secret as FileSecret from config package

### DIFF
--- a/config/http_config.go
+++ b/config/http_config.go
@@ -718,11 +718,15 @@ func (s *InlineSecret) Immutable() bool {
 	return true
 }
 
-type fileSecret struct {
+type FileSecret struct {
 	file string
 }
 
-func (s *fileSecret) Fetch(ctx context.Context) (string, error) {
+func NewFileSecret(file string) *FileSecret {
+	return &FileSecret{file: file}
+}
+
+func (s *FileSecret) Fetch(ctx context.Context) (string, error) {
 	fileBytes, err := os.ReadFile(s.file)
 	if err != nil {
 		return "", fmt.Errorf("unable to read file %s: %w", s.file, err)
@@ -730,11 +734,11 @@ func (s *fileSecret) Fetch(ctx context.Context) (string, error) {
 	return strings.TrimSpace(string(fileBytes)), nil
 }
 
-func (s *fileSecret) Description() string {
+func (s *FileSecret) Description() string {
 	return fmt.Sprintf("file %s", s.file)
 }
 
-func (s *fileSecret) Immutable() bool {
+func (s *FileSecret) Immutable() bool {
 	return false
 }
 
@@ -763,9 +767,7 @@ func toSecret(secretManager SecretManager, text Secret, file, ref string) (Secre
 		return NewInlineSecret(string(text)), nil
 	}
 	if file != "" {
-		return &fileSecret{
-			file: file,
-		}, nil
+		return NewFileSecret(file), nil
 	}
 	if ref != "" {
 		if secretManager == nil {

--- a/config/http_config_test.go
+++ b/config/http_config_test.go
@@ -756,7 +756,7 @@ func TestBearerAuthFileRoundTripper(t *testing.T) {
 	}, nil, nil)
 
 	// Normal flow.
-	bearerAuthRoundTripper := NewAuthorizationCredentialsRoundTripper("Bearer", &fileSecret{file: BearerTokenFile}, fakeRoundTripper)
+	bearerAuthRoundTripper := NewAuthorizationCredentialsRoundTripper("Bearer", &FileSecret{file: BearerTokenFile}, fakeRoundTripper)
 	request, _ := http.NewRequest("GET", "/hitchhiker", nil)
 	request.Header.Set("User-Agent", "Douglas Adams mind")
 	_, err := bearerAuthRoundTripper.RoundTrip(request)
@@ -765,7 +765,7 @@ func TestBearerAuthFileRoundTripper(t *testing.T) {
 	}
 
 	// Should honor already Authorization header set.
-	bearerAuthRoundTripperShouldNotModifyExistingAuthorization := NewAuthorizationCredentialsRoundTripper("Bearer", &fileSecret{file: MissingBearerTokenFile}, fakeRoundTripper)
+	bearerAuthRoundTripperShouldNotModifyExistingAuthorization := NewAuthorizationCredentialsRoundTripper("Bearer", &FileSecret{file: MissingBearerTokenFile}, fakeRoundTripper)
 	request, _ = http.NewRequest("GET", "/hitchhiker", nil)
 	request.Header.Set("Authorization", ExpectedBearer)
 	_, err = bearerAuthRoundTripperShouldNotModifyExistingAuthorization.RoundTrip(request)


### PR DESCRIPTION
Similar to https://github.com/prometheus/common/pull/650

Thanos also need the FileSecret to be exposed:

See: https://github.com/thanos-io/thanos/blob/c08dc141dd671f9c6ecc6dd85a9f39f8be32419c/pkg/clientconfig/http.go#L167

and https://github.com/prometheus/common/pull/538#issuecomment-2150596862