### PR TITLE
chore: add HumanizeTimestamp; make ConvertToFloat exportable

### DIFF
--- a/helpers/templates/time_test.go
+++ b/helpers/templates/time_test.go
@@ -103,6 +103,9 @@ func TestHumanizeTimestamp(t *testing.T) {
 		{name: "infinity", input: math.Inf(1), expected: "+Inf"},
 		{name: "minus infinity", input: math.Inf(-1), expected: "-Inf"},
 		{name: "NaN", input: math.NaN(), expected: "NaN"},
+		// Sampled data
+		{name: "sample float64", input: 1435065584.128, expected: "2015-06-23 13:19:44.128 +0000 UTC"},
+		{name: "sample string", input: "1435065584.128", expected: "2015-06-23 13:19:44.128 +0000 UTC"},
 	}
 
 	for _, tt := range tc {
@@ -117,16 +120,4 @@ func TestHumanizeTimestamp(t *testing.T) {
 func TestHumanizeTimestampError(t *testing.T) {
 	_, err := HumanizeTimestamp(math.MaxInt64)
 	require.Error(t, err)
-}
-
-func TestHumanizeTimestampSampleFloat64(t *testing.T) {
-	result, err := HumanizeTimestamp(1435065584.128)
-	require.NoError(t, err)
-	require.Equal(t, "2015-06-23 13:19:44.128 +0000 UTC", result)
-}
-
-func TestHumanizeTimestampSampleString(t *testing.T) {
-	result, err := HumanizeTimestamp(1435065584.128)
-	require.NoError(t, err)
-	require.Equal(t, "2015-06-23 13:19:44.128 +0000 UTC", result)
 }

--- a/helpers/templates/time_test.go
+++ b/helpers/templates/time_test.go
@@ -23,9 +23,10 @@ import (
 func TestHumanizeDurationSecondsFloat64(t *testing.T) {
 	tc := []struct {
 		name     string
-		input    float64
+		input    interface{}
 		expected string
 	}{
+		// Integers
 		{name: "zero", input: 0, expected: "0s"},
 		{name: "one second", input: 1, expected: "1s"},
 		{name: "one minute", input: 60, expected: "1m 0s"},
@@ -33,24 +34,8 @@ func TestHumanizeDurationSecondsFloat64(t *testing.T) {
 		{name: "one day", input: 86400, expected: "1d 0h 0m 0s"},
 		{name: "one day and one hour", input: 86400 + 3600, expected: "1d 1h 0m 0s"},
 		{name: "negative duration", input: -(86400*2 + 3600*3 + 60*4 + 5), expected: "-2d 3h 4m 5s"},
+		// Float64 with fractions
 		{name: "using a float", input: 899.99, expected: "14m 59s"},
-	}
-
-	for _, tt := range tc {
-		t.Run(tt.name, func(t *testing.T) {
-			result, err := HumanizeDuration(tt.input)
-			require.NoError(t, err)
-			require.Equal(t, tt.expected, result)
-		})
-	}
-}
-
-func TestHumanizeDurationSubsecondAndFractionalSecondsFloat64(t *testing.T) {
-	tc := []struct {
-		name     string
-		input    float64
-		expected string
-	}{
 		{name: "millseconds", input: .1, expected: "100ms"},
 		{name: "nanoseconds", input: .0001, expected: "100us"},
 		{name: "milliseconds + nanoseconds", input: .12345, expected: "123.5ms"},
@@ -58,6 +43,25 @@ func TestHumanizeDurationSubsecondAndFractionalSecondsFloat64(t *testing.T) {
 		{name: "minute + milliseconds", input: 60.5, expected: "1m 0s"},
 		{name: "second + milliseconds", input: 1.2345, expected: "1.234s"},
 		{name: "second + milliseconds rounded", input: 12.345, expected: "12.35s"},
+		// String
+		{name: "zero", input: "0", expected: "0s"},
+		{name: "second", input: "1", expected: "1s"},
+		{name: "minute", input: "60", expected: "1m 0s"},
+		{name: "hour", input: "3600", expected: "1h 0m 0s"},
+		{name: "day", input: "86400", expected: "1d 0h 0m 0s"},
+		// String with fractions
+		{name: "millseconds", input: ".1", expected: "100ms"},
+		{name: "nanoseconds", input: ".0001", expected: "100us"},
+		{name: "milliseconds + nanoseconds", input: ".12345", expected: "123.5ms"},
+		{name: "minute + millisecond", input: "60.1", expected: "1m 0s"},
+		{name: "minute + milliseconds", input: "60.5", expected: "1m 0s"},
+		{name: "second + milliseconds", input: "1.2345", expected: "1.234s"},
+		{name: "second + milliseconds rounded", input: "12.345", expected: "12.35s"},
+		// Int
+		{name: "zero", input: 0, expected: "0s"},
+		{name: "negative", input: -1, expected: "-1s"},
+		{name: "second", input: 1, expected: "1s"},
+		{name: "days", input: 1234567, expected: "14d 6h 56m 7s"},
 	}
 
 	for _, tt := range tc {
@@ -74,105 +78,31 @@ func TestHumanizeDurationErrorString(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestHumanizeDurationSecondsString(t *testing.T) {
-	tc := []struct {
-		name     string
-		input    string
-		expected string
-	}{
-		{name: "zero", input: "0", expected: "0s"},
-		{name: "second", input: "1", expected: "1s"},
-		{name: "minute", input: "60", expected: "1m 0s"},
-		{name: "hour", input: "3600", expected: "1h 0m 0s"},
-		{name: "day", input: "86400", expected: "1d 0h 0m 0s"},
-	}
-
-	for _, tt := range tc {
-		t.Run(tt.name, func(t *testing.T) {
-			result, err := HumanizeDuration(tt.input)
-			require.NoError(t, err)
-			require.Equal(t, tt.expected, result)
-		})
-	}
-}
-
-func TestHumanizeDurationSubsecondAndFractionalSecondsString(t *testing.T) {
-	tc := []struct {
-		name     string
-		input    string
-		expected string
-	}{
-		{name: "millseconds", input: ".1", expected: "100ms"},
-		{name: "nanoseconds", input: ".0001", expected: "100us"},
-		{name: "milliseconds + nanoseconds", input: ".12345", expected: "123.5ms"},
-		{name: "minute + millisecond", input: "60.1", expected: "1m 0s"},
-		{name: "minute + milliseconds", input: "60.5", expected: "1m 0s"},
-		{name: "second + milliseconds", input: "1.2345", expected: "1.234s"},
-		{name: "second + milliseconds rounded", input: "12.345", expected: "12.35s"},
-	}
-
-	for _, tt := range tc {
-		t.Run(tt.name, func(t *testing.T) {
-			result, err := HumanizeDuration(tt.input)
-			require.NoError(t, err)
-			require.Equal(t, tt.expected, result)
-		})
-	}
-}
-
-func TestHumanizeDurationSecondsInt(t *testing.T) {
-	tc := []struct {
-		name     string
-		input    int
-		expected string
-	}{
-		{name: "zero", input: 0, expected: "0s"},
-		{name: "negative", input: -1, expected: "-1s"},
-		{name: "second", input: 1, expected: "1s"},
-		{name: "days", input: 1234567, expected: "14d 6h 56m 7s"},
-	}
-
-	for _, tt := range tc {
-		t.Run(tt.name, func(t *testing.T) {
-			result, err := HumanizeDuration(tt.input)
-			require.NoError(t, err)
-			require.Equal(t, tt.expected, result)
-		})
-	}
-}
-
 func TestHumanizeTimestampInt(t *testing.T) {
 	tc := []struct {
 		name     string
-		input    int
+		input    interface{}
 		expected string
 	}{
+		// Int
 		{name: "zero", input: 0, expected: "1970-01-01 00:00:00 +0000 UTC"},
 		{name: "negative", input: -1, expected: "1969-12-31 23:59:59 +0000 UTC"},
 		{name: "one", input: 1, expected: "1970-01-01 00:00:01 +0000 UTC"},
 		{name: "past", input: 1234567, expected: "1970-01-15 06:56:07 +0000 UTC"},
 		{name: "future", input: 9223372036, expected: "2262-04-11 23:47:16 +0000 UTC"},
-	}
-
-	for _, tt := range tc {
-		t.Run(tt.name, func(t *testing.T) {
-			result, err := HumanizeTimestamp(tt.input)
-			require.NoError(t, err)
-			require.Equal(t, tt.expected, result)
-		})
-	}
-}
-
-func TestHumanizeTimestampUint(t *testing.T) {
-	tc := []struct {
-		name     string
-		input    uint64
-		expected string
-	}{
-		{name: "zero", input: 0, expected: "1970-01-01 00:00:00 +0000 UTC"},
-		{name: "one", input: 1, expected: "1970-01-01 00:00:01 +0000 UTC"},
-		{name: "past", input: 1234567, expected: "1970-01-15 06:56:07 +0000 UTC"},
-		{name: "future", input: 9223372036, expected: "2262-04-11 23:47:16 +0000 UTC"},
+		// Uint
+		{name: "zero", input: uint64(0), expected: "1970-01-01 00:00:00 +0000 UTC"},
+		{name: "one", input: uint64(1), expected: "1970-01-01 00:00:01 +0000 UTC"},
+		{name: "past", input: uint64(1234567), expected: "1970-01-15 06:56:07 +0000 UTC"},
+		{name: "future", input: uint64(9223372036), expected: "2262-04-11 23:47:16 +0000 UTC"},
+		// NaN/Inf, strings
+		{name: "infinity", input: "+Inf", expected: "+Inf"},
+		{name: "minus infinity", input: "-Inf", expected: "-Inf"},
+		{name: "NaN", input: "NaN", expected: "NaN"},
+		// Nan/Inf, float64
+		{name: "infinity", input: math.Inf(1), expected: "+Inf"},
+		{name: "minus infinity", input: math.Inf(-1), expected: "-Inf"},
+		{name: "NaN", input: math.NaN(), expected: "NaN"},
 	}
 
 	for _, tt := range tc {
@@ -187,46 +117,6 @@ func TestHumanizeTimestampUint(t *testing.T) {
 func TestHumanizeTimestampError(t *testing.T) {
 	_, err := HumanizeTimestamp(math.MaxInt64)
 	require.Error(t, err)
-}
-
-func TestHumanizeTimestampInfNanString(t *testing.T) {
-	tc := []struct {
-		name     string
-		input    string
-		expected string
-	}{
-		{name: "infinity", input: "+Inf", expected: "+Inf"},
-		{name: "minus infinity", input: "-Inf", expected: "-Inf"},
-		{name: "NaN", input: "NaN", expected: "NaN"},
-	}
-
-	for _, tt := range tc {
-		t.Run(tt.name, func(t *testing.T) {
-			result, err := HumanizeTimestamp(tt.input)
-			require.NoError(t, err)
-			require.Equal(t, tt.expected, result)
-		})
-	}
-}
-
-func TestHumanizeTimestampInfNanFloat(t *testing.T) {
-	tc := []struct {
-		name     string
-		input    float64
-		expected string
-	}{
-		{name: "infinity", input: math.Inf(1), expected: "+Inf"},
-		{name: "minus infinity", input: math.Inf(-1), expected: "-Inf"},
-		{name: "NaN", input: math.NaN(), expected: "NaN"},
-	}
-
-	for _, tt := range tc {
-		t.Run(tt.name, func(t *testing.T) {
-			result, err := HumanizeTimestamp(tt.input)
-			require.NoError(t, err)
-			require.Equal(t, tt.expected, result)
-		})
-	}
 }
 
 func TestHumanizeTimestampSampleFloat64(t *testing.T) {

--- a/helpers/templates/time_test.go
+++ b/helpers/templates/time_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestHumanizeDurationSecondsFloat64(t *testing.T) {
+func TestHumanizeDuration(t *testing.T) {
 	tc := []struct {
 		name     string
 		input    interface{}
@@ -78,7 +78,7 @@ func TestHumanizeDurationErrorString(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestHumanizeTimestampInt(t *testing.T) {
+func TestHumanizeTimestamp(t *testing.T) {
 	tc := []struct {
 		name     string
 		input    interface{}

--- a/helpers/templates/time_test.go
+++ b/helpers/templates/time_test.go
@@ -14,6 +14,7 @@
 package templates
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -138,4 +139,104 @@ func TestHumanizeDurationSecondsInt(t *testing.T) {
 			require.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func TestHumanizeTimestampInt(t *testing.T) {
+	tc := []struct {
+		name     string
+		input    int
+		expected string
+	}{
+		{name: "zero", input: 0, expected: "1970-01-01 00:00:00 +0000 UTC"},
+		{name: "negative", input: -1, expected: "1969-12-31 23:59:59 +0000 UTC"},
+		{name: "one", input: 1, expected: "1970-01-01 00:00:01 +0000 UTC"},
+		{name: "past", input: 1234567, expected: "1970-01-15 06:56:07 +0000 UTC"},
+		{name: "future", input: 9223372036, expected: "2262-04-11 23:47:16 +0000 UTC"},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := HumanizeTimestamp(tt.input)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestHumanizeTimestampUint(t *testing.T) {
+	tc := []struct {
+		name     string
+		input    uint64
+		expected string
+	}{
+		{name: "zero", input: 0, expected: "1970-01-01 00:00:00 +0000 UTC"},
+		{name: "one", input: 1, expected: "1970-01-01 00:00:01 +0000 UTC"},
+		{name: "past", input: 1234567, expected: "1970-01-15 06:56:07 +0000 UTC"},
+		{name: "future", input: 9223372036, expected: "2262-04-11 23:47:16 +0000 UTC"},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := HumanizeTimestamp(tt.input)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestHumanizeTimestampError(t *testing.T) {
+	_, err := HumanizeTimestamp(math.MaxInt64)
+	require.Error(t, err)
+}
+
+func TestHumanizeTimestampInfNanString(t *testing.T) {
+	tc := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{name: "infinity", input: "+Inf", expected: "+Inf"},
+		{name: "minus infinity", input: "-Inf", expected: "-Inf"},
+		{name: "NaN", input: "NaN", expected: "NaN"},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := HumanizeTimestamp(tt.input)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestHumanizeTimestampInfNanFloat(t *testing.T) {
+	tc := []struct {
+		name     string
+		input    float64
+		expected string
+	}{
+		{name: "infinity", input: math.Inf(1), expected: "+Inf"},
+		{name: "minus infinity", input: math.Inf(-1), expected: "-Inf"},
+		{name: "NaN", input: math.NaN(), expected: "NaN"},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := HumanizeTimestamp(tt.input)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestHumanizeTimestampSampleFloat64(t *testing.T) {
+	result, err := HumanizeTimestamp(1435065584.128)
+	require.NoError(t, err)
+	require.Equal(t, "2015-06-23 13:19:44.128 +0000 UTC", result)
+}
+
+func TestHumanizeTimestampSampleString(t *testing.T) {
+	result, err := HumanizeTimestamp(1435065584.128)
+	require.NoError(t, err)
+	require.Equal(t, "2015-06-23 13:19:44.128 +0000 UTC", result)
 }


### PR DESCRIPTION
See the discussion here: https://github.com/prometheus/prometheus/pull/14202

Basically copied HumanizeTimestamp from prometheus repo to move it there and added some tests (basically refactored to avoid using templating), the idea is to remove its implementation and the implementation of ConvertToFloat (which are both used in alertmanager and prometheus repos) from both prometheus and alertmanager repos to include the implementation from this repo.

@gotjosh can you check?