### PR TITLE
Set http_headers to be omit empty

### DIFF
--- a/config/http_config.go
+++ b/config/http_config.go
@@ -323,7 +323,7 @@ type HTTPClientConfig struct {
 	ProxyConfig `yaml:",inline"`
 	// HTTPHeaders specify headers to inject in the requests. Those headers
 	// could be marshalled back to the users.
-	HTTPHeaders *Headers `yaml:"http_headers" json:"http_headers"`
+	HTTPHeaders *Headers `yaml:"http_headers,omitempty" json:"http_headers,omitempty"`
 }
 
 // SetDirectory joins any relative file paths with dir.

--- a/config/http_config_test.go
+++ b/config/http_config_test.go
@@ -2023,7 +2023,6 @@ func TestHTTPClientConfig_Marshal(t *testing.T) {
 proxy_url: "http://localhost:8080"
 follow_redirects: false
 enable_http2: false
-http_headers: null
 `, string(actualYAML))
 
 			// Unmarshalling the YAML should get the same struct in input.
@@ -2040,8 +2039,7 @@ http_headers: null
 				"proxy_url":"http://localhost:8080",
 				"tls_config":{"insecure_skip_verify":false},
 				"follow_redirects":false,
-				"enable_http2":false,
-				"http_headers":null
+				"enable_http2":false
 			}`, string(actualJSON))
 
 			// Unmarshalling the JSON should get the same struct in input.


### PR DESCRIPTION
https://github.com/prometheus/common/pull/416 was introduced in release v0.54.0 to allow `http_headers` in the http client config. 

This PR marks this new field omit empty so that an older version of Prometheus can run successfully using a config file marshalled with the newer version of the common library.