### PR TITLE
remove dependency to github.com/prometheus/client_golang

### DIFF
--- a/sigv4/go.mod
+++ b/sigv4/go.mod
@@ -6,7 +6,6 @@ replace github.com/prometheus/common => ../
 
 require (
 	github.com/aws/aws-sdk-go v1.54.7
-	github.com/prometheus/client_golang v1.19.1
 	github.com/prometheus/common v0.53.0
 	github.com/stretchr/testify v1.9.0
 	gopkg.in/yaml.v2 v2.4.0
@@ -22,6 +21,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/prometheus/client_golang v1.19.1 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	golang.org/x/net v0.26.0 // indirect


### PR DESCRIPTION
Remove dependency to `github.com/prometheus/client_golang`

`client_golang` depends on this module, so it doesn't make sense for this module to depend on `client_golang`.
This can cause `go.sum` file of user repos to be very very large and make it very slow to download deps and build.
Also makes it much harder to fork these two modules.
It's just a design problem.