### PR TITLE
Re-export FmtText as a deprecated constant.

### DIFF
--- a/expfmt/decode.go
+++ b/expfmt/decode.go
@@ -64,7 +64,7 @@ func ResponseFormat(h http.Header) Format {
 		if v, ok := params["version"]; ok && v != TextVersion {
 			return fmtUnknown
 		}
-		return fmtText
+		return FmtText
 	}
 
 	return fmtUnknown

--- a/expfmt/decode_test.go
+++ b/expfmt/decode_test.go
@@ -460,11 +460,11 @@ func testDiscriminatorHTTPHeader(t testing.TB) {
 		},
 		{
 			input:  map[string]string{"Content-Type": `text/plain; version=0.0.4`},
-			output: fmtText,
+			output: FmtText,
 		},
 		{
 			input:  map[string]string{"Content-Type": `text/plain`},
-			output: fmtText,
+			output: FmtText,
 		},
 		{
 			input:  map[string]string{"Content-Type": `text/plain; version=0.0.3`},
@@ -574,7 +574,7 @@ func TestTextDecoderWithBufioReader(t *testing.T) {
 
 	var decoded bool
 	r := bufio.NewReader(strings.NewReader(example))
-	dec := NewDecoder(r, fmtText)
+	dec := NewDecoder(r, FmtText)
 	for {
 		var mf dto.MetricFamily
 		if err := dec.Decode(&mf); err != nil {

--- a/expfmt/encode.go
+++ b/expfmt/encode.go
@@ -85,10 +85,10 @@ func Negotiate(h http.Header) Format {
 			}
 		}
 		if ac.Type == "text" && ac.SubType == "plain" && (ver == TextVersion || ver == "") {
-			return fmtText + escapingScheme
+			return FmtText + escapingScheme
 		}
 	}
-	return fmtText + escapingScheme
+	return FmtText + escapingScheme
 }
 
 // NegotiateIncludingOpenMetrics works like Negotiate but includes
@@ -118,7 +118,7 @@ func NegotiateIncludingOpenMetrics(h http.Header) Format {
 			}
 		}
 		if ac.Type == "text" && ac.SubType == "plain" && (ver == TextVersion || ver == "") {
-			return fmtText + escapingScheme
+			return FmtText + escapingScheme
 		}
 		if ac.Type+"/"+ac.SubType == OpenMetricsType && (ver == OpenMetricsVersion_0_0_1 || ver == OpenMetricsVersion_1_0_0 || ver == "") {
 			switch ver {
@@ -129,7 +129,7 @@ func NegotiateIncludingOpenMetrics(h http.Header) Format {
 			}
 		}
 	}
-	return fmtText + escapingScheme
+	return FmtText + escapingScheme
 }
 
 // NewEncoder returns a new encoder based on content type negotiation. All

--- a/expfmt/encode_test.go
+++ b/expfmt/encode_test.go
@@ -237,7 +237,7 @@ func TestEncode(t *testing.T) {
 		// 4: Untyped fmtText
 		{
 			metric: metric1,
-			format: fmtText,
+			format: FmtText,
 			expOut: `# TYPE foo_metric untyped
 foo_metric 1.234
 `,
@@ -372,7 +372,7 @@ func TestEscapedEncode(t *testing.T) {
 
 	buff.Reset()
 
-	textEncoder := NewEncoder(&buff, fmtText)
+	textEncoder := NewEncoder(&buff, FmtText)
 	err = textEncoder.Encode(metric)
 	if err != nil {
 		t.Errorf("unexpected error during encode: %s", err.Error())

--- a/expfmt/expfmt.go
+++ b/expfmt/expfmt.go
@@ -43,8 +43,15 @@ const (
 	// The Content-Type values for the different wire protocols. Note that these
 	// values are now unexported. If code was relying on comparisons to these
 	// constants, instead use FormatType().
-	fmtUnknown           Format = `<unknown>`
-	fmtText              Format = `text/plain; version=` + TextVersion + `; charset=utf-8`
+	fmtUnknown Format = `<unknown>`
+
+	// FmtText defines a Content-Type for the basic plaintext protocol.
+	//
+	// Deprecated: FmtText should not be used directly in code. With the addition
+	// of the escaping term, format strings now have many permutations and doing
+	// direct string comparisons of formats is not reliable. Instead, users should
+	// call FormatType and compare the result against the possible enum values.
+	FmtText              Format = `text/plain; version=` + TextVersion + `; charset=utf-8`
 	fmtProtoDelim        Format = protoFmt + ` encoding=delimited`
 	fmtProtoText         Format = protoFmt + ` encoding=text`
 	fmtProtoCompact      Format = protoFmt + ` encoding=compact-text`
@@ -85,7 +92,7 @@ func NewFormat(t FormatType) Format {
 	case TypeProtoText:
 		return fmtProtoText
 	case TypeTextPlain:
-		return fmtText
+		return FmtText
 	case TypeOpenMetrics:
 		return fmtOpenMetrics_1_0_0
 	default:

--- a/expfmt/expfmt_test.go
+++ b/expfmt/expfmt_test.go
@@ -44,7 +44,7 @@ func TestToFormatType(t *testing.T) {
 			expected: TypeOpenMetrics,
 		},
 		{
-			format:   fmtText,
+			format:   FmtText,
 			expected: TypeTextPlain,
 		},
 		{


### PR DESCRIPTION
Based on the conversation in https://github.com/prometheus/common/pull/576, removing FmtText as an exported constant breaks a lot of existing code.  This change re-exports that value, though marks it as deprecated.