### PR TITLE
expfmt: Add UTF-8 syntax support in text_parse.go

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -58,7 +58,7 @@ endif
 PROMU_VERSION ?= 0.17.0
 PROMU_URL     := https://github.com/prometheus/promu/releases/download/v$(PROMU_VERSION)/promu-$(PROMU_VERSION).$(GO_BUILD_PLATFORM).tar.gz
 
-SKIP_GOLANGCI_LINT :=
+SKIP_GOLANGCI_LINT := true
 GOLANGCI_LINT :=
 GOLANGCI_LINT_OPTS ?=
 GOLANGCI_LINT_VERSION ?= v1.59.1

--- a/Makefile.common
+++ b/Makefile.common
@@ -58,7 +58,7 @@ endif
 PROMU_VERSION ?= 0.17.0
 PROMU_URL     := https://github.com/prometheus/promu/releases/download/v$(PROMU_VERSION)/promu-$(PROMU_VERSION).$(GO_BUILD_PLATFORM).tar.gz
 
-SKIP_GOLANGCI_LINT := true
+SKIP_GOLANGCI_LINT :=
 GOLANGCI_LINT :=
 GOLANGCI_LINT_OPTS ?=
 GOLANGCI_LINT_VERSION ?= v1.59.1

--- a/expfmt/text_parse.go
+++ b/expfmt/text_parse.go
@@ -665,7 +665,6 @@ func (p *TextParser) readTokenAsMetricName() {
 			case 'n':
 				p.currentToken.WriteByte('\n')
 			case '"':
-				p.currentToken.WriteByte('\\')
 				p.currentToken.WriteByte('"')
 			default:
 				p.parseError(fmt.Sprintf("invalid escape sequence '\\%c'", p.currentByte))
@@ -716,7 +715,6 @@ func (p *TextParser) readTokenAsLabelName() {
 			case 'n':
 				p.currentToken.WriteByte('\n')
 			case '"':
-				p.currentToken.WriteByte('\\')
 				p.currentToken.WriteByte('"')
 			default:
 				p.parseError(fmt.Sprintf("invalid escape sequence '\\%c'", p.currentByte))

--- a/expfmt/text_parse.go
+++ b/expfmt/text_parse.go
@@ -294,7 +294,6 @@ func (p *TextParser) startLabelName() stateFn {
 		p.parseError(fmt.Sprintf("invalid label name for metric %q", p.currentMF.GetName()))
 		return nil
 	}
-	// TODO(fedetorres93): check for metric name inside braces before other labels.
 	if p.skipBlankTabIfCurrentBlankTab(); p.err != nil {
 		return nil // Unexpected end of input.
 	}
@@ -306,10 +305,6 @@ func (p *TextParser) startLabelName() stateFn {
 				p.currentMetric = &dto.Metric{}
 				return p.startLabelName
 			case '}':
-				/*				if p.currentMF == nil {
-								p.parseError("invalid metric name")
-								return nil
-							}*/
 				p.setOrCreateCurrentMF()
 				p.currentMetric = &dto.Metric{}
 				p.currentMetric.Label = append(p.currentMetric.Label, p.currentLabel...)
@@ -337,16 +332,8 @@ func (p *TextParser) startLabelName() stateFn {
 	// labels to 'real' labels.
 	if !(p.currentMF.GetType() == dto.MetricType_SUMMARY && p.currentLabelPair.GetName() == model.QuantileLabel) &&
 		!(p.currentMF.GetType() == dto.MetricType_HISTOGRAM && p.currentLabelPair.GetName() == model.BucketLabel) {
-		//p.currentMetric.Label = append(p.currentMetric.Label, p.currentLabelPair)
 		p.currentLabel = append(p.currentLabel, p.currentLabelPair)
 	}
-	//if p.skipBlankTabIfCurrentBlankTab(); p.err != nil {
-	//	return nil // Unexpected end of input.
-	//}
-	//if p.currentByte != '=' {
-	//	p.parseError(fmt.Sprintf("expected '=' after label name, found %q", p.currentByte))
-	//	return nil
-	//}
 	// Check for duplicate label names.
 	labels := make(map[string]struct{})
 	for _, l := range p.currentLabel {
@@ -637,7 +624,6 @@ func (p *TextParser) readTokenUntilNewline(recognizeEscapeSequence bool) {
 			case 'n':
 				p.currentToken.WriteByte('\n')
 			case '"':
-				//p.currentToken.WriteByte('\\')
 				p.currentToken.WriteByte('"')
 			default:
 				p.parseError(fmt.Sprintf("invalid escape sequence '\\%c'", p.currentByte))
@@ -685,21 +671,14 @@ func (p *TextParser) readTokenAsMetricName() {
 				return
 			}
 			escaped = false
-			/*			p.currentByte, p.err = p.buf.ReadByte()
-						continue*/
 		} else {
 			switch p.currentByte {
 			case '"':
-				//p.currentToken.WriteByte(p.currentByte)
-				//p.currentByte, p.err = p.buf.ReadByte()
 				quoted = !quoted
 				if !quoted {
 					p.currentByte, p.err = p.buf.ReadByte()
 					return
 				}
-				/*			if p.err != nil || !isValidMetricNameContinuation(p.currentByte, quoted) {
-							return
-						}*/
 			case '\n':
 				p.parseError(fmt.Sprintf("metric name %q contains unescaped new-line", p.currentToken.String()))
 				return
@@ -707,10 +686,6 @@ func (p *TextParser) readTokenAsMetricName() {
 				escaped = true
 			default:
 				p.currentToken.WriteByte(p.currentByte)
-				/*				p.currentByte, p.err = p.buf.ReadByte()
-								if p.err != nil || !isValidMetricNameContinuation(p.currentByte, quoted) || (!quoted && p.currentByte == ' ') {
-									return
-								}*/
 			}
 		}
 		p.currentByte, p.err = p.buf.ReadByte()
@@ -747,20 +722,14 @@ func (p *TextParser) readTokenAsLabelName() {
 				return
 			}
 			escaped = false
-			//continue
 		} else {
 			switch p.currentByte {
 			case '"':
-				//p.currentToken.WriteByte(p.currentByte)
-				//p.currentByte, p.err = p.buf.ReadByte()
 				quoted = !quoted
 				if !quoted {
 					p.currentByte, p.err = p.buf.ReadByte()
 					return
 				}
-				/*			if p.err != nil || !isValidLabelNameContinuation(p.currentByte, quoted) {
-							return
-						}*/
 			case '\n':
 				p.parseError(fmt.Sprintf("label name %q contains unescaped new-line", p.currentToken.String()))
 				return
@@ -768,10 +737,6 @@ func (p *TextParser) readTokenAsLabelName() {
 				escaped = true
 			default:
 				p.currentToken.WriteByte(p.currentByte)
-				/*			p.currentByte, p.err = p.buf.ReadByte()
-							if p.err != nil || !isValidLabelNameContinuation(p.currentByte, quoted) || (!quoted && p.currentByte == '=') {
-								return
-							}*/
 			}
 		}
 		p.currentByte, p.err = p.buf.ReadByte()

--- a/expfmt/text_parse.go
+++ b/expfmt/text_parse.go
@@ -319,11 +319,10 @@ func (p *TextParser) startLabelName() stateFn {
 				p.parseError(fmt.Sprintf("unexpected end of metric value %q", p.currentByte))
 				return nil
 			}
-		} else {
-			p.parseError(fmt.Sprintf("expected '=' after label name, found %q", p.currentByte))
-			p.currentLabel = nil
-			return nil
 		}
+		p.parseError(fmt.Sprintf("expected '=' after label name, found %q", p.currentByte))
+		p.currentLabel = nil
+		return nil
 	}
 	p.currentLabelPair = &dto.LabelPair{Name: proto.String(p.currentToken.String())}
 	if p.currentLabelPair.GetName() == string(model.MetricNameLabel) {

--- a/expfmt/text_parse.go
+++ b/expfmt/text_parse.go
@@ -306,10 +306,12 @@ func (p *TextParser) startLabelName() stateFn {
 				p.currentMetric = &dto.Metric{}
 				return p.startLabelName
 			case '}':
-				if p.currentMF == nil {
-					p.parseError("invalid metric name")
-					return nil
-				}
+				/*				if p.currentMF == nil {
+								p.parseError("invalid metric name")
+								return nil
+							}*/
+				p.setOrCreateCurrentMF()
+				p.currentMetric = &dto.Metric{}
 				p.currentMetric.Label = append(p.currentMetric.Label, p.currentLabel...)
 				p.currentLabel = nil
 				if p.skipBlankTab(); p.err != nil {
@@ -681,7 +683,7 @@ func (p *TextParser) readTokenAsMetricName() {
 		}
 		switch p.currentByte {
 		case '"':
-			p.currentToken.WriteByte(p.currentByte)
+			//p.currentToken.WriteByte(p.currentByte)
 			p.currentByte, p.err = p.buf.ReadByte()
 			quoted = !quoted
 			if !quoted {
@@ -733,7 +735,7 @@ func (p *TextParser) readTokenAsLabelName() {
 		}
 		switch p.currentByte {
 		case '"':
-			p.currentToken.WriteByte(p.currentByte)
+			//p.currentToken.WriteByte(p.currentByte)
 			p.currentByte, p.err = p.buf.ReadByte()
 			quoted = !quoted
 			if !quoted {

--- a/expfmt/text_parse.go
+++ b/expfmt/text_parse.go
@@ -18,14 +18,15 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	dto "github.com/prometheus/client_model/go"
-	"github.com/prometheus/common/model"
-	"google.golang.org/protobuf/proto"
 	"io"
 	"math"
 	"strconv"
 	"strings"
 	"unicode/utf8"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/model"
+	"google.golang.org/protobuf/proto"
 )
 
 // A stateFn is a function that represents a state in a state machine. By

--- a/expfmt/text_parse.go
+++ b/expfmt/text_parse.go
@@ -25,8 +25,9 @@ import (
 	"unicode/utf8"
 
 	dto "github.com/prometheus/client_model/go"
-	"github.com/prometheus/common/model"
 	"google.golang.org/protobuf/proto"
+
+	"github.com/prometheus/common/model"
 )
 
 // A stateFn is a function that represents a state in a state machine. By

--- a/expfmt/text_parse.go
+++ b/expfmt/text_parse.go
@@ -301,6 +301,10 @@ func (p *TextParser) startLabelName() stateFn {
 	}
 	if p.currentByte != '=' {
 		if p.currentMetricIsInsideBraces {
+			if p.currentMF != nil && p.currentMF.GetName() != p.currentToken.String() {
+				p.parseError(fmt.Sprintf("multiple metric names %s %s", p.currentMF.GetName(), p.currentToken.String()))
+				return nil
+			}
 			switch p.currentByte {
 			case ',':
 				p.setOrCreateCurrentMF()

--- a/expfmt/text_parse.go
+++ b/expfmt/text_parse.go
@@ -320,7 +320,7 @@ func (p *TextParser) startLabelName() stateFn {
 				}
 				return p.readingValue
 			default:
-				p.parseError(fmt.Sprintf("unexpected end of metric value %q", p.currentByte))
+				p.parseError(fmt.Sprintf("unexpected end of metric name %q", p.currentByte))
 				return nil
 			}
 		}

--- a/expfmt/text_parse_test.go
+++ b/expfmt/text_parse_test.go
@@ -589,6 +589,7 @@ metric_bucket{le="bla"} 3.14
 `,
 			err: "text format parsing error in line 3: expected float as value for 'le' label",
 		},
+		// TODO(fedetorres93): check if this test should now pass (it's testing a label value, so I think it's ok)
 		// 19: Invalid UTF-8 in label value.
 		{
 			in:  "metric{l=\"\xbd\"} 3.14\n",
@@ -671,7 +672,6 @@ metric{quantile="0x1p-3"} 3.14
 			err: "text format parsing error in line 1: duplicate label names for metric",
 		},
 	}
-
 	for i, scenario := range scenarios {
 		_, err := parser.TextToMetricFamilies(strings.NewReader(scenario.in))
 		if err == nil {

--- a/expfmt/text_parse_test.go
+++ b/expfmt/text_parse_test.go
@@ -33,7 +33,7 @@ func testTextParse(t testing.TB) {
 			in: `
 		# HELP "my.noncompliant.metric" help text
 		# TYPE "my.noncompliant.metric" counter
-		{"my.noncompliant.metric", label="value"} 1
+		{"my.noncompliant.metric", "label.name"="value"} 1
 		`,
 			out: []*dto.MetricFamily{
 				{
@@ -44,7 +44,7 @@ func testTextParse(t testing.TB) {
 						{
 							Label: []*dto.LabelPair{
 								{
-									Name:  proto.String("label"),
+									Name:  proto.String("\"label.name\""),
 									Value: proto.String("value"),
 								},
 							},

--- a/expfmt/text_parse_test.go
+++ b/expfmt/text_parse_test.go
@@ -538,6 +538,34 @@ request_duration_microseconds_count 2693
 				},
 			},
 		},
+		// 9: Various escaped special characters in metric and label names.
+		{
+			in: `
+# HELP "my\"noncompliant\nmetric" help text
+# TYPE "my\"noncompliant\nmetric" counter
+{"my\"noncompliant\nmetric","label\"name\n"="value"} 1
+`,
+			out: []*dto.MetricFamily{
+				{
+					Name: proto.String("my\"noncompliant\nmetric"),
+					Help: proto.String("help text"),
+					Type: dto.MetricType_COUNTER.Enum(),
+					Metric: []*dto.Metric{
+						{
+							Label: []*dto.LabelPair{
+								{
+									Name:  proto.String("label\"name\n"),
+									Value: proto.String("value"),
+								},
+							},
+							Counter: &dto.Counter{
+								Value: proto.Float64(1),
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for i, scenario := range scenarios {

--- a/expfmt/text_parse_test.go
+++ b/expfmt/text_parse_test.go
@@ -556,8 +556,8 @@ request_duration_microseconds_count 2693
 			got, ok := out[expected.GetName()]
 			if !ok {
 				t.Errorf(
-					"%d. expected MetricFamily %q, found none. got %q",
-					i, expected.GetName(), got.GetName(),
+					"%d. expected MetricFamily %q, found none",
+					i, expected.GetName(),
 				)
 				continue
 			}
@@ -700,7 +700,6 @@ metric 4.12
 			in:  `@invalidmetric{label="bla"} 3.14 2`,
 			err: "text format parsing error in line 1: invalid metric name",
 		},
-		// TODO(fedetorres93): this test is failing because the metric starts with braces but has no metric name in it. Fix logic to take this into account (add another stateFn?)
 		// 17:
 		{
 			in:  `{label="bla"} 3.14 2`,
@@ -714,7 +713,6 @@ metric_bucket{le="bla"} 3.14
 `,
 			err: "text format parsing error in line 3: expected float as value for 'le' label",
 		},
-		// TODO(fedetorres93): check if this test should now pass (it's testing a label value, so I think it's ok)
 		// 19: Invalid UTF-8 in label value.
 		{
 			in:  "metric{l=\"\xbd\"} 3.14\n",

--- a/expfmt/text_parse_test.go
+++ b/expfmt/text_parse_test.go
@@ -566,6 +566,34 @@ request_duration_microseconds_count 2693
 				},
 			},
 		},
+		// 10: Quoted metric name, not the first element in the label set.
+		{
+			in: `
+# HELP "my.noncompliant.metric" help text
+# TYPE "my.noncompliant.metric" counter
+{labelname="value", "my.noncompliant.metric"} 1
+`,
+			out: []*dto.MetricFamily{
+				{
+					Name: proto.String("my.noncompliant.metric"),
+					Help: proto.String("help text"),
+					Type: dto.MetricType_COUNTER.Enum(),
+					Metric: []*dto.Metric{
+						{
+							Label: []*dto.LabelPair{
+								{
+									Name:  proto.String("labelname"),
+									Value: proto.String("value"),
+								},
+							},
+							Counter: &dto.Counter{
+								Value: proto.Float64(1),
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for i, scenario := range scenarios {

--- a/expfmt/text_parse_test.go
+++ b/expfmt/text_parse_test.go
@@ -385,7 +385,7 @@ request_duration_microseconds_count 2693
 				},
 			},
 		},
-		// 5: UTF-8 counter
+		// 5: Quoted metric name and quoted label name with dots.
 		{
 			in: `
 # HELP "my.noncompliant.metric" help text
@@ -413,7 +413,7 @@ request_duration_microseconds_count 2693
 				},
 			},
 		},
-		// 6: Dots in name
+		// 6: Metric family with dots in name.
 		{
 			in: `
 # HELP "name.with.dots" boring help
@@ -462,7 +462,7 @@ request_duration_microseconds_count 2693
 				},
 			},
 		},
-		// 6: Dots in name, no labels
+		// 7: Metric family with dots in name, no labels.
 		{
 			in: `
 				# HELP "name.with.dots" boring help
@@ -491,7 +491,7 @@ request_duration_microseconds_count 2693
 				},
 			},
 		},
-		// 7: Gauge, UTF-8, +Inf as value, multi-byte characters in label values.
+		// 8: Quoted metric name and quoted label names with dots and asterisks, special characters in label values.
 		{
 			in: `# HELP "gauge.name" gauge\ndoc\nstr\"ing
 # TYPE "gauge.name" gauge

--- a/expfmt/text_parse_test.go
+++ b/expfmt/text_parse_test.go
@@ -850,6 +850,11 @@ metric{quantile="0x1p-3"} 3.14
 			in:  `metric{label="bla",label="bla"} 3.14`,
 			err: "text format parsing error in line 1: duplicate label names for metric",
 		},
+		// 34: Multiple metric names.
+		{
+			in:  `{"one.name","another.name"} 3.14`,
+			err: "text format parsing error in line 1: multiple metric names",
+		},
 	}
 	for i, scenario := range scenarios {
 		_, err := parser.TextToMetricFamilies(strings.NewReader(scenario.in))

--- a/expfmt/text_parse_test.go
+++ b/expfmt/text_parse_test.go
@@ -850,10 +850,15 @@ metric{quantile="0x1p-3"} 3.14
 			in:  `metric{label="bla",label="bla"} 3.14`,
 			err: "text format parsing error in line 1: duplicate label names for metric",
 		},
-		// 34: Multiple metric names.
+		// 34: Multiple quoted metric names.
 		{
 			in:  `{"one.name","another.name"} 3.14`,
 			err: "text format parsing error in line 1: multiple metric names",
+		},
+		// 35: Invalid escape sequence in quoted metric name.
+		{
+			in:  `{"a\xc5z",label="bla"} 3.14`,
+			err: "text format parsing error in line 1: invalid escape sequence",
 		},
 	}
 	for i, scenario := range scenarios {


### PR DESCRIPTION
This PR adds support for the new UTF-8 syntax proposed [here](https://github.com/prometheus/proposals/blob/main/proposals/2023-08-21-utf8.md). 

Main changes:

- Metric names may include UTF-8 characters and, if so, they will be quoted and inside brackets, without an operator (for example: `{"my.metric", label="value"} 1`)
- Label names may include UTF-8 characters and, if so, they will be quoted (for example: `{"my.metric", "my.label"="value"} 1`)

Addresses https://github.com/prometheus/common/issues/554