### PR TITLE
enable utf-8 validation mode by default

### DIFF
--- a/model/alert_test.go
+++ b/model/alert_test.go
@@ -100,6 +100,8 @@ func TestAlertValidate(t *testing.T) {
 		},
 	}
 
+	NameValidationScheme = LegacyValidation
+
 	for i, c := range cases {
 		err := c.alert.Validate()
 		if err == nil {

--- a/model/metric.go
+++ b/model/metric.go
@@ -32,7 +32,7 @@ var (
 	// UTF-8-aware binaries as part of their startup. To avoid need for locking,
 	// this value should be set once, ideally in an init(), before multiple
 	// goroutines are started.
-	NameValidationScheme = LegacyValidation
+	NameValidationScheme = UTF8Validation
 
 	// NameEscapingScheme defines the default way that names will be
 	// escaped when presented to systems that do not support UTF-8 names. If the


### PR DESCRIPTION
part of https://github.com/prometheus/prometheus/issues/13095

This should be part of Prometheus 3.0, do we need a separate feature branch for the common library so we can schedule when the change is committed?