### PR TITLE
fix(utf8): provide a method for explicitly checking label names for legacy validity

### DIFF
--- a/model/labels.go
+++ b/model/labels.go
@@ -97,25 +97,34 @@ var LabelNameRE = regexp.MustCompile("^[a-zA-Z_][a-zA-Z0-9_]*$")
 // therewith.
 type LabelName string
 
-// IsValid returns true iff name matches the pattern of LabelNameRE for legacy
-// names, and iff it's valid UTF-8 if NameValidationScheme is set to
-// UTF8Validation. For the legacy matching, it does not use LabelNameRE for the
-// check but a much faster hardcoded implementation.
+// IsValid returns true iff the name matches the pattern of LabelNameRE when
+// NameValidationScheme is set to LegacyValidation, or valid UTF-8 if
+// NameValidationScheme is set to UTF8Validation.
 func (ln LabelName) IsValid() bool {
 	if len(ln) == 0 {
 		return false
 	}
 	switch NameValidationScheme {
 	case LegacyValidation:
-		for i, b := range ln {
-			if !((b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || b == '_' || (b >= '0' && b <= '9' && i > 0)) {
-				return false
-			}
-		}
+		return ln.IsValidLegacy()
 	case UTF8Validation:
 		return utf8.ValidString(string(ln))
 	default:
 		panic(fmt.Sprintf("Invalid name validation scheme requested: %d", NameValidationScheme))
+	}
+}
+
+// IsValidLegacy returns true iff name matches the pattern of LabelNameRE for
+// legacy names. It does not use LabelNameRE for the check but a much faster
+// hardcoded implementation.
+func (ln LabelName) IsValidLegacy() bool {
+	if len(ln) == 0 {
+		return false
+	}
+	for i, b := range ln {
+		if !((b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || b == '_' || (b >= '0' && b <= '9' && i > 0)) {
+			return false
+		}
 	}
 	return true
 }


### PR DESCRIPTION
This is needed in Prometheus for modes when legacy validation has been explicitly requested but UTF-8 is otherwise enabled.

part of https://github.com/prometheus/prometheus/issues/13095
part of https://github.com/prometheus/prometheus/issues/14728