### PR TITLE
Change the default escape method to UnderscoreEscaping

### DIFF
--- a/expfmt/encode_test.go
+++ b/expfmt/encode_test.go
@@ -383,9 +383,9 @@ func TestEscapedEncode(t *testing.T) {
 		t.Errorf("expected the output bytes buffer to be non-empty")
 	}
 
-	expected := `# TYPE U__foo_2e_metric untyped
-U__foo_2e_metric 1.234
-U__foo_2e_metric{U__dotted_2e_label_2e_name="my.label.value"} 8
+	expected := `# TYPE foo_metric untyped
+foo_metric 1.234
+foo_metric{dotted_label_name="my.label.value"} 8
 `
 
 	if string(out) != expected {

--- a/expfmt/expfmt_test.go
+++ b/expfmt/expfmt_test.go
@@ -105,11 +105,11 @@ func TestToEscapingScheme(t *testing.T) {
 	}{
 		{
 			format:   FmtProtoCompact,
-			expected: model.ValueEncodingEscaping,
+			expected: model.UnderscoreEscaping,
 		},
 		{
-			format:   "application/openmetrics-text; version=1.0.0; charset=utf-8; escaping=underscores",
-			expected: model.UnderscoreEscaping,
+			format:   "application/openmetrics-text; version=1.0.0; charset=utf-8; escaping=dots",
+			expected: model.DotsEscaping,
 		},
 		{
 			format:   "application/openmetrics-text; version=1.0.0; charset=utf-8; escaping=allow-utf-8",

--- a/model/metric.go
+++ b/model/metric.go
@@ -34,10 +34,13 @@ var (
 	// goroutines are started.
 	NameValidationScheme = LegacyValidation
 
-	// NameEscapingScheme defines the default way that names will be
-	// escaped when presented to systems that do not support UTF-8 names. If the
-	// Content-Type "escaping" term is specified, that will override this value.
-	NameEscapingScheme = ValueEncodingEscaping
+	// NameEscapingScheme defines the default way that names will be escaped when
+	// presented to systems that do not support UTF-8 names. If the Content-Type
+	// "escaping" term is specified, that will override this value.
+	// NameEscapingScheme should not be set to the NoEscaping value. That string
+	// is used in content negotiation to indicate that a system supports UTF-8 and
+	// has that feature enabled.
+	NameEscapingScheme = UnderscoreEscaping
 )
 
 // ValidationScheme is a Go enum for determining how metric and label names will


### PR DESCRIPTION
fixes https://github.com/prometheus/common/issues/689