### PR TITLE
fix(utf8): Fix multiple metric name inside braces validation

### DIFF
--- a/expfmt/text_parse.go
+++ b/expfmt/text_parse.go
@@ -73,8 +73,10 @@ type TextParser struct {
 	// These tell us if the currently processed line ends on '_count' or
 	// '_sum' respectively and belong to a summary/histogram, representing the sample
 	// count and sum of that summary/histogram.
-	currentIsSummaryCount, currentIsSummarySum                      bool
-	currentIsHistogramCount, currentIsHistogramSum                  bool
+	currentIsSummaryCount, currentIsSummarySum     bool
+	currentIsHistogramCount, currentIsHistogramSum bool
+	// These indicate if the metric name from the current line being parsed is inside
+	// braces and if that metric name was found respectively.
 	currentMetricIsInsideBraces, currentMetricInsideBracesIsPresent bool
 }
 

--- a/expfmt/text_parse_test.go
+++ b/expfmt/text_parse_test.go
@@ -594,6 +594,49 @@ request_duration_microseconds_count 2693
 				},
 			},
 		},
+		// 11: Multiple minimal metrics with quoted metric names.
+		{
+			in: `
+{"name.1"} 1
+{"name.2"} 1
+{"name.3"} 1
+`,
+			out: []*dto.MetricFamily{
+				{
+					Name: proto.String("name.1"),
+					Type: dto.MetricType_UNTYPED.Enum(),
+					Metric: []*dto.Metric{
+						{
+							Untyped: &dto.Untyped{
+								Value: proto.Float64(1),
+							},
+						},
+					},
+				},
+				{
+					Name: proto.String("name.2"),
+					Type: dto.MetricType_UNTYPED.Enum(),
+					Metric: []*dto.Metric{
+						{
+							Untyped: &dto.Untyped{
+								Value: proto.Float64(1),
+							},
+						},
+					},
+				},
+				{
+					Name: proto.String("name.3"),
+					Type: dto.MetricType_UNTYPED.Enum(),
+					Metric: []*dto.Metric{
+						{
+							Untyped: &dto.Untyped{
+								Value: proto.Float64(1),
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for i, scenario := range scenarios {


### PR DESCRIPTION
There's a bug where metrics inside braces in different lines are mistakenly considered as multiple metric names in the same line when there's no TYPE or HELP line. This PR addresses the issue.

Related to https://github.com/prometheus/common/pull/670