### PR TITLE
slog: expose io.Writer

### DIFF
--- a/promslog/slog.go
+++ b/promslog/slog.go
@@ -148,10 +148,10 @@ func (f *AllowedFormat) Set(s string) error {
 
 // Config is a struct containing configurable settings for the logger
 type Config struct {
-	Level    *AllowedLevel
-	Format   *AllowedFormat
-	Style    LogStyle
-	ioWriter io.Writer
+	Level  *AllowedLevel
+	Format *AllowedFormat
+	Style  LogStyle
+	Writer io.Writer
 }
 
 // New returns a new slog.Logger. Each logged line will be annotated
@@ -162,8 +162,8 @@ func New(config *Config) *slog.Logger {
 		_ = config.Level.Set("info")
 	}
 
-	if config.ioWriter == nil {
-		config.ioWriter = defaultWriter
+	if config.Writer == nil {
+		config.Writer = defaultWriter
 	}
 
 	logHandlerOpts := &slog.HandlerOptions{
@@ -176,7 +176,7 @@ func New(config *Config) *slog.Logger {
 	}
 
 	if config.Format != nil && config.Format.s == "json" {
-		return slog.New(slog.NewJSONHandler(config.ioWriter, logHandlerOpts))
+		return slog.New(slog.NewJSONHandler(config.Writer, logHandlerOpts))
 	}
-	return slog.New(slog.NewTextHandler(config.ioWriter, logHandlerOpts))
+	return slog.New(slog.NewTextHandler(config.Writer, logHandlerOpts))
 }

--- a/promslog/slog_test.go
+++ b/promslog/slog_test.go
@@ -112,7 +112,7 @@ func TestDynamicLevels(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			buf.Reset() // Ensure buf is reset prior to tests
-			config := &Config{ioWriter: &buf, Style: tc.logStyle}
+			config := &Config{Writer: &buf, Style: tc.logStyle}
 			logger := New(config)
 
 			// Test that log level can be adjusted on-the-fly to debug and that a


### PR DESCRIPTION
While implementing the new slog logger at windows_exporter, I figure out that I'm unable to set the Writer as I could on slog.

Define the Writer is important for windows. stdout and stderr are not captured, if programs running as Windows Service. 

On windows_exporter, I implement a io.Writer which is able to write data to the Windows Event Log and I would like to use that writer.