### PR TITLE
feat: add `promslog.NewNopLogger()` convenience func

### DIFF
--- a/promslog/slog.go
+++ b/promslog/slog.go
@@ -180,3 +180,9 @@ func New(config *Config) *slog.Logger {
 	}
 	return slog.New(slog.NewTextHandler(config.Writer, logHandlerOpts))
 }
+
+// NewNopLogger is a convenience function to return an slog.Logger that writes
+// to io.Discard.
+func NewNopLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}


### PR DESCRIPTION
Simple convenience function to return an slog.Logger that writes to io.Discard. Originally suggested by @ArthurSens
[here](https://github.com/prometheus/common/pull/686#issuecomment-2336501004), and requested again by @bboreham
[here](https://github.com/prometheus/prometheus/pull/14906#discussion_r1770597610). As Bryan points out in the comment, there's 147 instances where a discard logger is needed, so a consistent utility function to manage them seems helpful.