### PR TITLE
Support Application-Layer Protocol negotiation via nextProtos flag in tlsconfig

### DIFF
--- a/config/http_config.go
+++ b/config/http_config.go
@@ -1069,6 +1069,10 @@ func NewTLSConfigWithContext(ctx context.Context, cfg *TLSConfig, optFuncs ...TL
 		tlsConfig.ServerName = cfg.ServerName
 	}
 
+	if len(cfg.NextProtos) > 0 {
+		tlsConfig.NextProtos = cfg.NextProtos
+	}
+
 	// If a client cert & key is provided then configure TLS config accordingly.
 	if cfg.usingClientCert() && cfg.usingClientKey() {
 		// Verify that client cert and key are valid.
@@ -1118,6 +1122,8 @@ type TLSConfig struct {
 	MinVersion TLSVersion `yaml:"min_version,omitempty" json:"min_version,omitempty"`
 	// Maximum TLS version.
 	MaxVersion TLSVersion `yaml:"max_version,omitempty" json:"max_version,omitempty"`
+	// Additional ALPN protocols to be presented when connecting to the server.
+	NextProtos []string `yaml:"next_protos,omitempty" json:"next_protos,omitempty"`
 }
 
 // SetDirectory joins any relative file paths with dir.

--- a/config/testdata/tls_config.next_protos.good.json
+++ b/config/testdata/tls_config.next_protos.good.json
@@ -1,0 +1,1 @@
+{"next_protos": ["testproto1", "testproto2"]}

--- a/config/testdata/tls_config.next_protos.good.json
+++ b/config/testdata/tls_config.next_protos.good.json
@@ -1,1 +1,1 @@
-{"next_protos": ["testproto1", "testproto2"]}
+{"next_protos": ["h2", "http/1.1"]}

--- a/config/testdata/tls_config.next_protos.good.yml
+++ b/config/testdata/tls_config.next_protos.good.yml
@@ -1,0 +1,1 @@
+next_protos: ["testproto1", "testproto2"]

--- a/config/testdata/tls_config.next_protos.good.yml
+++ b/config/testdata/tls_config.next_protos.good.yml
@@ -1,1 +1,1 @@
-next_protos: ["testproto1", "testproto2"]
+next_protos: ["h2", "http/1.1"]

--- a/config/tls_config_test.go
+++ b/config/tls_config_test.go
@@ -65,7 +65,7 @@ var expectedTLSConfigs = []struct {
 	},
 	{
 		filename: "tls_config.next_protos.good.json",
-		config:   &tls.Config{NextProtos: []string{"testproto1", "testproto2"}},
+		config:   &tls.Config{NextProtos: []string{"h2", "http/1.1"}},
 	},
 	{
 		filename: "tls_config.tlsversion.good.json",
@@ -85,7 +85,7 @@ var expectedTLSConfigs = []struct {
 	},
 	{
 		filename: "tls_config.next_protos.good.yml",
-		config:   &tls.Config{NextProtos: []string{"testproto1", "testproto2"}},
+		config:   &tls.Config{NextProtos: []string{"h2", "http/1.1"}},
 	},
 	{
 		filename: "tls_config.tlsversion.good.yml",

--- a/config/tls_config_test.go
+++ b/config/tls_config_test.go
@@ -64,6 +64,10 @@ var expectedTLSConfigs = []struct {
 		config:   &tls.Config{InsecureSkipVerify: true},
 	},
 	{
+		filename: "tls_config.next_protos.good.json",
+		config:   &tls.Config{NextProtos: []string{"testproto1", "testproto2"}},
+	},
+	{
 		filename: "tls_config.tlsversion.good.json",
 		config:   &tls.Config{MinVersion: tls.VersionTLS11},
 	},
@@ -78,6 +82,10 @@ var expectedTLSConfigs = []struct {
 	{
 		filename: "tls_config.insecure.good.yml",
 		config:   &tls.Config{InsecureSkipVerify: true},
+	},
+	{
+		filename: "tls_config.next_protos.good.yml",
+		config:   &tls.Config{NextProtos: []string{"testproto1", "testproto2"}},
 	},
 	{
 		filename: "tls_config.tlsversion.good.yml",


### PR DESCRIPTION
Allows fallback based on protocol availability and support for custom protocols securely over TLS.

ptal:
@roidelapluie
@gotjosh
@ArthurSens