### PR TITLE
Mark sigv4 deprecated

### DIFF
--- a/sigv4/sigv4.go
+++ b/sigv4/sigv4.go
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Deprecated: This package has been migrated to github.com/prometheus/sigv4.
 package sigv4
 
 import (


### PR DESCRIPTION
Mark the sigv4 module deprecated in favor of the new repo location.
* https://github.com/prometheus/sigv4

Closes: https://github.com/prometheus/common/issues/709