### PR TITLE
Provide a way to get UserAgent

### DIFF
--- a/version/info.go
+++ b/version/info.go
@@ -90,6 +90,10 @@ func GetTags() string {
 	return computedTags
 }
 
+func UserAgent() string {
+	return "Prometheus/" + Version
+}
+
 func init() {
 	computedRevision, computedTags = computeRevision()
 }


### PR DESCRIPTION
In Prometheus, the userAgent is calculated the same way in several places:

https://github.com/search?q=repo%3Aprometheus%2Fprometheus%20userAgent&type=code

This exposes a function that can be used instead 

```go
import "github.com/prometheus/common/version"

version.UserAgent()
```