### PR TITLE
Mark promlog deprecated

### DIFF
--- a/promlog/flag/flag.go
+++ b/promlog/flag/flag.go
@@ -11,6 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Deprecated: This package has been deprecated in favor of migrating to
+// `github.com/prometheus/common/promslog` which uses the Go standard library
+// `log/slog` package.
 package flag
 
 import (
@@ -18,7 +21,7 @@ import (
 
 	kingpin "github.com/alecthomas/kingpin/v2"
 
-	"github.com/prometheus/common/promlog"
+	"github.com/prometheus/common/promlog" //nolint:staticcheck
 )
 
 // LevelFlagName is the canonical flag name to configure the allowed log level

--- a/promlog/log.go
+++ b/promlog/log.go
@@ -14,6 +14,10 @@
 // Package promlog defines standardised ways to initialize Go kit loggers
 // across Prometheus components.
 // It should typically only ever be imported by main packages.
+//
+// Deprecated: This package has been deprecated in favor of migrating to
+// `github.com/prometheus/common/promslog` which uses the Go standard library
+// `log/slog` package.
 package promlog
 
 import (


### PR DESCRIPTION
Now that all Prometheus repos have been migrated to the `promslog` package, mark `promlog` as deprecated.