### PR TITLE
Open user-agent definition

### DIFF
--- a/version/info.go
+++ b/version/info.go
@@ -95,7 +95,7 @@ func PrometheusUserAgent() string {
 }
 
 func ComponentUserAgent(component string) string {
-	return fmt.Sprintf("%s/%s", component, Version)
+	return component+"/"+Version
 }
 
 func init() {

--- a/version/info.go
+++ b/version/info.go
@@ -95,7 +95,7 @@ func PrometheusUserAgent() string {
 }
 
 func ComponentUserAgent(component string) string {
-	return component+"/"+Version
+	return component + "/" + Version
 }
 
 func init() {

--- a/version/info.go
+++ b/version/info.go
@@ -90,8 +90,12 @@ func GetTags() string {
 	return computedTags
 }
 
-func UserAgent() string {
-	return "Prometheus/" + Version
+func PrometheusUserAgent() string {
+	return ComponentUserAgent("Prometheus")
+}
+
+func ComponentUserAgent(component string) string {
+	return fmt.Sprintf("%s/%s", component, Version)
 }
 
 func init() {

--- a/version/info_test.go
+++ b/version/info_test.go
@@ -20,9 +20,9 @@ import (
 )
 
 func TestPrometheusUserAgent(t *testing.T) {
-	require.Equal(t, "Prometheus/" + Version, PrometheusUserAgent())
+	require.Equal(t, "Prometheus/"+Version, PrometheusUserAgent())
 }
 
 func TestComponentUserAgent(t *testing.T) {
-	require.Equal(t, "Component/" + Version, ComponentUserAgent("Component"))
+	require.Equal(t, "Component/"+Version, ComponentUserAgent("Component"))
 }

--- a/version/info_test.go
+++ b/version/info_test.go
@@ -1,0 +1,28 @@
+// Copyright 2024 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+import (
+  "testing"
+
+	"github.com/stretchr/testify/require"
+  )
+
+func TestPrometheusUserAgent(t *testing.T) {
+  require.Equal(t, "Prometheus/" + Version, PrometheusUserAgent())
+}
+
+func TestComponentUserAgent(t *testing.T) {
+  require.Equal(t, "Component/" + Version, ComponentUserAgent("Component"))
+}

--- a/version/info_test.go
+++ b/version/info_test.go
@@ -14,15 +14,15 @@
 package version
 
 import (
-  "testing"
+	"testing"
 
 	"github.com/stretchr/testify/require"
-  )
+)
 
 func TestPrometheusUserAgent(t *testing.T) {
-  require.Equal(t, "Prometheus/" + Version, PrometheusUserAgent())
+	require.Equal(t, "Prometheus/" + Version, PrometheusUserAgent())
 }
 
 func TestComponentUserAgent(t *testing.T) {
-  require.Equal(t, "Component/" + Version, ComponentUserAgent("Component"))
+	require.Equal(t, "Component/" + Version, ComponentUserAgent("Component"))
 }


### PR DESCRIPTION
Most of the time the User-agent is Prometheus/Version but might be changed to Component/Version in certain occasion.
This expose a PrometheusUserAgent which is the most common case and also provide a ComponentUserAgent to support a component customization.