### PR TITLE
promslog: always lowercase log level from CLI

### DIFF
--- a/promslog/slog.go
+++ b/promslog/slog.go
@@ -115,7 +115,7 @@ func (l *AllowedLevel) Set(s string) error {
 		l.lvl = &slog.LevelVar{}
 	}
 
-	switch s {
+	switch strings.ToLower(s) {
 	case "debug":
 		l.lvl.Set(slog.LevelDebug)
 		callerAddFunc = true


### PR DESCRIPTION
The `--log.level` argument now relaxes casing by converting all input from end-users to lowercase. 

This allows end-users to set `log.level` to values like `DEBUG`.