### PR TITLE
fix(promslog): always use UTC for time

### DIFF
--- a/promslog/slog.go
+++ b/promslog/slog.go
@@ -68,13 +68,16 @@ var (
 
 		return a
 	}
-	truncateSourceAttrFunc = func(groups []string, a slog.Attr) slog.Attr {
-		if a.Key != slog.SourceKey {
-			return a
-		}
-
-		if src, ok := a.Value.Any().(*slog.Source); ok {
+	defaultReplaceAttrFunc = func(groups []string, a slog.Attr) slog.Attr {
+		key := a.Key
+		switch key {
+		case slog.TimeKey:
+			t := a.Value.Time()
+			a.Value = slog.TimeValue(t.UTC())
+		case slog.SourceKey:
+			src, _ := a.Value.Any().(*slog.Source)
 			a.Value = slog.StringValue(filepath.Base(src.File) + ":" + strconv.Itoa(src.Line))
+		default:
 		}
 
 		return a
@@ -178,7 +181,7 @@ func New(config *Config) *slog.Logger {
 	logHandlerOpts := &slog.HandlerOptions{
 		Level:       config.Level.lvl,
 		AddSource:   true,
-		ReplaceAttr: truncateSourceAttrFunc,
+		ReplaceAttr: defaultReplaceAttrFunc,
 	}
 
 	if config.Style == GoKitStyle {


### PR DESCRIPTION
@superq and I have both called this out in a few places; finally remembering to fix it.

Prometheus has a UTC policy for logging because UTC is also used for metrics and so they should correlate.

Before:
```
=== RUN   TestDynamicLevels/slog_log_style
time=2024-12-02T13:51:08.463-05:00 level=INFO source=slog_test.go:120 msg=info hello=world
time=2024-12-02T13:51:08.463-05:00 level=DEBUG source=slog_test.go:121 msg=debug hello=world
```

After:
```
=== RUN   TestDynamicLevels/slog_log_style
time=2024-12-04T19:51:59.813Z level=INFO source=slog_test.go:120 msg=info hello=world
time=2024-12-04T19:51:59.813Z level=DEBUG source=slog_test.go:121 msg=debug hello=world
```