### PR TITLE
promslog: Use the default timezone (again)

### DIFF
--- a/promslog/slog.go
+++ b/promslog/slog.go
@@ -200,9 +200,8 @@ func defaultReplaceAttr(_ []string, a slog.Attr) slog.Attr {
 	key := a.Key
 	switch key {
 	case slog.TimeKey:
-		if t, ok := a.Value.Any().(time.Time); ok {
-			a.Value = slog.TimeValue(t.UTC())
-		} else {
+		// Note that we do not change the timezone to UTC anymore.
+		if _, ok := a.Value.Any().(time.Time); !ok {
 			// If we can't cast the any from the value to a
 			// time.Time, it means the caller logged
 			// another attribute with a key of `time`.


### PR DESCRIPTION
This reverts commit 145b50adb4ece06ea09a5b0abcbedb76bd1b123a.

See discussion on Slack. We should first decide which log format we want before changing it from what is already released in prometheus/prometheus.


UPDATE:

This is the new commit description:

As per the dev-summit discussion, we want to use the default timezone
as selected by slog after all rather than a hardcoded UTC.

(This was accidentally introduced earlier when moving from gokit to
slog, but then switched back to hardcoded UTC in PR https://github.com/prometheus/common/pull/735.)

Environments that have configured UTC anyway won't see any difference,
but those with other timezones configured will see the configured
timezone for the timestamps in their logs. This is in line with how
slog behaves by default.

Example timestamp _before_ this change and also _after_ this change
with UTC configured in the environment via a suitable way (e.g.
setting `TZ=UTC` on Linux):

    time=2025-04-10T12:00:38.179Z

Example timestamp _after_ this change with location Europe/Berlin,
i.e. timezone is CET or CEST:

    time=2025-04-10T14:00:03.120+02:00

Note that the precise delta to UTC is in the timestamp. So this change
will also be transparent to the usual logs processing tools.