### PR TITLE
update links to openmetrics to reference the v1.0.0 release

### DIFF
--- a/expfmt/openmetrics_create.go
+++ b/expfmt/openmetrics_create.go
@@ -38,7 +38,7 @@ type EncoderOption func(*encoderOption)
 
 // WithCreatedLines is an EncoderOption that configures the OpenMetrics encoder
 // to include _created lines (See
-// https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#counter-1).
+// https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#counter-1).
 // Created timestamps can improve the accuracy of series reset detection, but
 // come with a bandwidth cost.
 //
@@ -102,7 +102,7 @@ func WithUnit() EncoderOption {
 //
 //   - According to the OM specs, the `# UNIT` line is optional, but if populated,
 //     the unit has to be present in the metric name as its suffix:
-//     (see https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#unit).
+//     (see https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#unit).
 //     However, in order to accommodate any potential scenario where such a change in the
 //     metric name is not desirable, the users are here given the choice of either explicitly
 //     opt in, in case they wish for the unit to be included in the output AND in the metric name


### PR DESCRIPTION
Related to https://github.com/prometheus/OpenMetrics/issues/287

The OM 2.0 effort is kicked off, and will start developing on main. This updates the links to OpenMetrics to reference the 1.0 release. The OM project has also been moved into the prometheus github org.