### PR TITLE
feat(promslog): implement reserved keys, rename duplicates

### DIFF
--- a/promslog/slog_test.go
+++ b/promslog/slog_test.go
@@ -218,9 +218,9 @@ func TestReservedKeys(t *testing.T) {
 			)
 
 			output := buf.String()
-			require.Contains(t, output, fmt.Sprintf("%s%s=\"%s\"", reservedKeyPrefix, tc.levelKey, reservedKeyTestVal), "Expected duplicate level key to be renamed")
-			require.Contains(t, output, fmt.Sprintf("%s%s=\"%s\"", reservedKeyPrefix, tc.sourceKey, reservedKeyTestVal), "Expected duplicate source key to be renamed")
-			require.Contains(t, output, fmt.Sprintf("%s%s=\"%s\"", reservedKeyPrefix, tc.timeKey, reservedKeyTestVal), "Expected duplicate time key to be renamed")
+			require.Containsf(t, output, fmt.Sprintf("%s%s=\"%s\"", reservedKeyPrefix, tc.levelKey, reservedKeyTestVal), "Expected duplicate level key to be renamed")
+			require.Containsf(t, output, fmt.Sprintf("%s%s=\"%s\"", reservedKeyPrefix, tc.sourceKey, reservedKeyTestVal), "Expected duplicate source key to be renamed")
+			require.Containsf(t, output, fmt.Sprintf("%s%s=\"%s\"", reservedKeyPrefix, tc.timeKey, reservedKeyTestVal), "Expected duplicate time key to be renamed")
 
 			// Print logs for humans to see, if needed.
 			fmt.Println(buf.String())


### PR DESCRIPTION
This commit adds support for "reserved" keys, where upon detecting a
duplicate log attribute key, it will rename the key to prevent
collisions/issues with core slog attribute keys in use.

The reserved keys are:
- `level`
- `source` (for standard slog style)
- `caller` (for legacy go-kit style)
- `time`   (for standard slog style)
- `ts`     (for legacy go-kit style)

By supporting reserved keys, we allow users of the library to use these
keys for their own supplemental log attributes.

Fixes: #745

Example test output:
```
=== RUN   TestReservedKeys/slog_log_style
time=2025-01-13T18:32:46.508Z level=INFO source=slog_test.go:212 msg="reserved keys test for slog_log_style" logged_level="surprise! I'm a string" logged_source="surprise! I'm a string" logged_time="surprise! I'm a string"

=== RUN   TestReservedKeys/go-kit_log_style
ts=2025-01-13T18:32:46.508Z level=info caller=slog_test.go:212 msg="reserved keys test for go-kit_log_style" logged_level="surprise! I'm a string" logged_caller="surprise! I'm a string" logged_ts="surprise! I'm a string"
```

Note: this implementation only technically removes duplicates of our
core reserved keys. If a user adds multiple instances of a reserved key,
the rest get renamed to `logged_$key`, which means there could be
duplicate attributes with `logged_$key`. This is mostly to simplify
implementation so we don't need to bother reference counting in the
replace attr function to do things like `logged_$key1`, `logged_$key2`,
etc.

Signed-off-by: TJ Hoplock <t.hoplock@gmail.com>
