### PR TITLE
Define code owners for otlptranslator

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+otlptranslator @aknuds1 @jesusvazquez


### PR DESCRIPTION
If OTLP translation code should be moved from Prometheus to the `otlptranslator` package in this repo, `otlptranslator` should have the same CODEOWNERS as in Prometheus.