### PR TITLE
refactor(promslog): make `NewNopLogger()` wrapper around `New()`

### DIFF
--- a/promslog/slog.go
+++ b/promslog/slog.go
@@ -266,10 +266,5 @@ func New(config *Config) *slog.Logger {
 // NewNopLogger is a convenience function to return an slog.Logger that writes
 // to io.Discard.
 func NewNopLogger() *slog.Logger {
-	// Set log level to debug, in case there are code paths that are only
-	// triggered when debug logging is enabled.
-	level := NewLevel()
-	_ = level.Set("debug")
-
-	return New(&Config{Level: level, Writer: io.Discard})
+	return New(&Config{Writer: io.Discard})
 }

--- a/promslog/slog.go
+++ b/promslog/slog.go
@@ -266,5 +266,10 @@ func New(config *Config) *slog.Logger {
 // NewNopLogger is a convenience function to return an slog.Logger that writes
 // to io.Discard.
 func NewNopLogger() *slog.Logger {
-	return slog.New(slog.NewTextHandler(io.Discard, nil))
+	// Set log level to debug, in case there are code paths that are only
+	// triggered when debug logging is enabled.
+	level := NewLevel()
+	_ = level.Set("debug")
+
+	return New(&Config{Level: level, Writer: io.Discard})
 }


### PR DESCRIPTION
While discussing the fix for prometheus/prometheus#16466, it was pointed
out that our `promslog.NewNopLogger()` convenience function would
benefit from using the same logic used when initializing loggers with
`promslog.New()`. By refactoring NewNopLogger to wrap New, it inherits
that same setup logic.

Signed-off-by: TJ Hoplock <t.hoplock@gmail.com>
