### PR TITLE
feat: Support negative duration in new function ParseDurationAllowNegative

### DIFF
--- a/model/time.go
+++ b/model/time.go
@@ -201,6 +201,7 @@ var unitMap = map[string]struct {
 
 // ParseDuration parses a string into a time.Duration, assuming that a year
 // always has 365d, a week always has 7d, and a day always has 24h.
+// Negative durations are not supported.
 func ParseDuration(s string) (Duration, error) {
 	switch s {
 	case "0":
@@ -257,9 +258,7 @@ func ParseDuration(s string) (Duration, error) {
 	return Duration(dur), nil
 }
 
-// ParseDurationAllowNegative parses a string into a time.Duration, assuming that a year
-// always has 365d, a week always has 7d, and a day always has 24h.
-// Supporting negative durations as well.
+// ParseDurationAllowNegative is like ParseDuration but also accepts negative durations.
 func ParseDurationAllowNegative(s string) (Duration, error) {
 	switch s {
 	case "0":

--- a/model/time.go
+++ b/model/time.go
@@ -214,6 +214,13 @@ func ParseDuration(s string) (Duration, error) {
 	var dur uint64
 	lastUnitPos := 0
 
+	// Check if duration is negative.
+	neg := false
+	if s[0] == '-' {
+		neg = true
+		s = s[1:]
+	}
+
 	for s != "" {
 		if !isdigit(s[0]) {
 			return 0, fmt.Errorf("not a valid duration string: %q", orig)
@@ -253,6 +260,12 @@ func ParseDuration(s string) (Duration, error) {
 			return 0, errors.New("duration out of range")
 		}
 	}
+
+	if neg {
+		// Return negative duration.
+		return Duration(-int64(dur)), nil
+	}
+
 	return Duration(dur), nil
 }
 
@@ -263,6 +276,12 @@ func (d Duration) String() string {
 	)
 	if ms == 0 {
 		return "0s"
+	}
+
+	// Handle negative duration.
+	neg := ms < 0
+	if neg {
+		ms = -ms
 	}
 
 	f := func(unit string, mult int64, exact bool) {
@@ -285,6 +304,11 @@ func (d Duration) String() string {
 	f("m", 1000*60, false)
 	f("s", 1000, false)
 	f("ms", 1, false)
+
+	if neg {
+		// Return negative duration.
+		return "-" + r
+	}
 
 	return r
 }

--- a/model/time.go
+++ b/model/time.go
@@ -278,16 +278,17 @@ func ParseDurationAllowNegative(s string) (Duration, error) {
 
 func (d Duration) String() string {
 	var (
-		ms = int64(time.Duration(d) / time.Millisecond)
-		r  = ""
+		ms   = int64(time.Duration(d) / time.Millisecond)
+		r    = ""
+		sign = ""
 	)
+
 	if ms == 0 {
 		return "0s"
 	}
 
-	negative := ms < 0
-	if negative {
-		ms = -ms
+	if ms < 0 {
+		sign, ms = "-", -ms
 	}
 
 	f := func(unit string, mult int64, exact bool) {
@@ -311,11 +312,7 @@ func (d Duration) String() string {
 	f("s", 1000, false)
 	f("ms", 1, false)
 
-	if negative {
-		return "-" + r
-	}
-
-	return r
+	return sign + r
 }
 
 // MarshalJSON implements the json.Marshaler interface.

--- a/model/time.go
+++ b/model/time.go
@@ -260,20 +260,13 @@ func ParseDuration(s string) (Duration, error) {
 
 // ParseDurationAllowNegative is like ParseDuration but also accepts negative durations.
 func ParseDurationAllowNegative(s string) (Duration, error) {
-	if s == "" {
-		return 0, errors.New("empty duration string")
-	}
-
-	if s[0] != '-' {
+	if s == "" || s[0] != '-' {
 		return ParseDuration(s)
 	}
 
 	d, err := ParseDuration(s[1:])
-	if err != nil {
-		return 0, err
-	}
 
-	return -d, nil
+	return -d, err
 }
 
 func (d Duration) String() string {

--- a/model/time_test.go
+++ b/model/time_test.go
@@ -118,6 +118,29 @@ func TestParseDuration(t *testing.T) {
 			in:  "10y",
 			out: 10 * 365 * 24 * time.Hour,
 		},
+		{
+			in:  "-3s",
+			out: -3 * time.Second,
+		}, {
+			in:  "-5m",
+			out: -5 * time.Minute,
+		}, {
+			in:  "-1h",
+			out: -1 * time.Hour,
+		}, {
+			in:  "-2d",
+			out: -2 * 24 * time.Hour,
+		}, {
+			in:  "-1w",
+			out: -7 * 24 * time.Hour,
+		}, {
+			in:             "-3w2d1h",
+			out:            -(3*7*24*time.Hour + 2*24*time.Hour + time.Hour),
+			expectedString: "-23d1h",
+		}, {
+			in:  "-10y",
+			out: -10 * 365 * 24 * time.Hour,
+		},
 	}
 
 	for _, c := range cases {

--- a/model/time_test.go
+++ b/model/time_test.go
@@ -330,7 +330,6 @@ func TestParseBadDuration(t *testing.T) {
 	cases := []string{
 		"1",
 		"1y1m1d",
-		"-1w",
 		"1.5d",
 		"d",
 		"294y",

--- a/model/time_test.go
+++ b/model/time_test.go
@@ -68,138 +68,172 @@ func TestDuration(t *testing.T) {
 }
 
 func TestParseDuration(t *testing.T) {
-	cases := []struct {
-		in  string
-		out time.Duration
 
-		expectedString string
-	}{
+	type testCase struct {
+		in              string
+		out             time.Duration
+		expectedString  string
+		allowedNegative bool
+	}
+
+	baseCases := []testCase{
 		{
-			in:             "0",
-			out:            0,
-			expectedString: "0s",
+			in:              "0",
+			out:             0,
+			expectedString:  "0s",
+			allowedNegative: false,
 		},
 		{
-			in:             "0w",
-			out:            0,
-			expectedString: "0s",
+			in:              "0w",
+			out:             0,
+			expectedString:  "0s",
+			allowedNegative: false,
 		},
 		{
-			in:  "0s",
-			out: 0,
+			in:              "0s",
+			out:             0,
+			expectedString:  "",
+			allowedNegative: false,
 		},
 		{
-			in:  "324ms",
-			out: 324 * time.Millisecond,
+			in:              "324ms",
+			out:             324 * time.Millisecond,
+			expectedString:  "",
+			allowedNegative: false,
 		},
 		{
-			in:  "3s",
-			out: 3 * time.Second,
+			in:              "3s",
+			out:             3 * time.Second,
+			expectedString:  "",
+			allowedNegative: false,
 		},
 		{
-			in:  "5m",
-			out: 5 * time.Minute,
+			in:              "5m",
+			out:             5 * time.Minute,
+			expectedString:  "",
+			allowedNegative: false,
 		},
 		{
-			in:  "1h",
-			out: time.Hour,
+			in:              "1h",
+			out:             time.Hour,
+			expectedString:  "",
+			allowedNegative: false,
 		},
 		{
-			in:  "4d",
-			out: 4 * 24 * time.Hour,
+			in:              "4d",
+			out:             4 * 24 * time.Hour,
+			expectedString:  "",
+			allowedNegative: false,
 		},
 		{
-			in:  "4d1h",
-			out: 4*24*time.Hour + time.Hour,
+			in:              "4d1h",
+			out:             4*24*time.Hour + time.Hour,
+			expectedString:  "",
+			allowedNegative: false,
 		},
 		{
-			in:             "14d",
-			out:            14 * 24 * time.Hour,
-			expectedString: "2w",
+			in:              "14d",
+			out:             14 * 24 * time.Hour,
+			expectedString:  "2w",
+			allowedNegative: false,
 		},
 		{
-			in:  "3w",
-			out: 3 * 7 * 24 * time.Hour,
+			in:              "3w",
+			out:             3 * 7 * 24 * time.Hour,
+			expectedString:  "",
+			allowedNegative: false,
 		},
 		{
-			in:             "3w2d1h",
-			out:            3*7*24*time.Hour + 2*24*time.Hour + time.Hour,
-			expectedString: "23d1h",
+			in:              "3w2d1h",
+			out:             3*7*24*time.Hour + 2*24*time.Hour + time.Hour,
+			expectedString:  "23d1h",
+			allowedNegative: false,
 		},
 		{
-			in:  "10y",
-			out: 10 * 365 * 24 * time.Hour,
+			in:              "10y",
+			out:             10 * 365 * 24 * time.Hour,
+			expectedString:  "",
+			allowedNegative: false,
 		},
 	}
 
-	casesAllowNegative := []struct {
-		in  string
-		out time.Duration
-
-		expectedString string
-	}{
+	negativeCases := []testCase{
 		{
-			in:  "-3s",
-			out: -3 * time.Second,
+			in:              "-3s",
+			out:             -3 * time.Second,
+			expectedString:  "",
+			allowedNegative: true,
 		},
 		{
-			in:  "-5m",
-			out: -5 * time.Minute,
+			in:              "-5m",
+			out:             -5 * time.Minute,
+			expectedString:  "",
+			allowedNegative: true,
 		},
 		{
-			in:  "-1h",
-			out: -1 * time.Hour,
+			in:              "-1h",
+			out:             -1 * time.Hour,
+			expectedString:  "",
+			allowedNegative: true,
 		},
 		{
-			in:  "-2d",
-			out: -2 * 24 * time.Hour,
+			in:              "-2d",
+			out:             -2 * 24 * time.Hour,
+			expectedString:  "",
+			allowedNegative: true,
 		},
 		{
-			in:  "-1w",
-			out: -7 * 24 * time.Hour,
+			in:              "-1w",
+			out:             -7 * 24 * time.Hour,
+			expectedString:  "",
+			allowedNegative: true,
 		},
 		{
-			in:             "-3w2d1h",
-			out:            -(3*7*24*time.Hour + 2*24*time.Hour + time.Hour),
-			expectedString: "-23d1h",
+			in:              "-3w2d1h",
+			out:             -(3*7*24*time.Hour + 2*24*time.Hour + time.Hour),
+			expectedString:  "-23d1h",
+			allowedNegative: true,
 		},
 		{
-			in:  "-10y",
-			out: -10 * 365 * 24 * time.Hour,
+			in:              "-10y",
+			out:             -10 * 365 * 24 * time.Hour,
+			expectedString:  "",
+			allowedNegative: true,
 		},
 	}
 
-	casesAllowNegative = append(casesAllowNegative, cases...)
+	for _, c := range baseCases {
+		c.allowedNegative = true
+		negativeCases = append(negativeCases, c)
+	}
 
-	for _, c := range cases {
-		d, err := ParseDuration(c.in)
+	allCases := append(baseCases, negativeCases...)
+
+	for _, c := range allCases {
+		var (
+			d   Duration
+			err error
+		)
+
+		if c.allowedNegative {
+			d, err = ParseDurationAllowNegative(c.in)
+		} else {
+			d, err = ParseDuration(c.in)
+		}
+
 		if err != nil {
 			t.Errorf("Unexpected error on input %q", c.in)
 		}
-		if time.Duration(d) != c.out {
-			t.Errorf("Expected %v but got %v", c.out, d)
-		}
-		expectedString := c.expectedString
-		if c.expectedString == "" {
-			expectedString = c.in
-		}
-		if d.String() != expectedString {
-			t.Errorf("Expected duration string %q but got %q", c.in, d.String())
-		}
-	}
 
-	for _, c := range casesAllowNegative {
-		d, err := ParseDurationAllowNegative(c.in)
-		if err != nil {
-			t.Errorf("Unexpected error on input %q", c.in)
-		}
 		if time.Duration(d) != c.out {
 			t.Errorf("Expected %v but got %v", c.out, d)
 		}
+
 		expectedString := c.expectedString
-		if c.expectedString == "" {
+		if expectedString == "" {
 			expectedString = c.in
 		}
+
 		if d.String() != expectedString {
 			t.Errorf("Expected duration string %q but got %q", c.in, d.String())
 		}

--- a/model/time_test.go
+++ b/model/time_test.go
@@ -130,6 +130,14 @@ func TestParseDuration(t *testing.T) {
 			in:  "10y",
 			out: 10 * 365 * 24 * time.Hour,
 		},
+	}
+
+	casesAllowNegative := []struct {
+		in  string
+		out time.Duration
+
+		expectedString string
+	}{
 		{
 			in:  "-3s",
 			out: -3 * time.Second,
@@ -161,8 +169,27 @@ func TestParseDuration(t *testing.T) {
 		},
 	}
 
+	casesAllowNegative = append(casesAllowNegative, cases...)
+
 	for _, c := range cases {
 		d, err := ParseDuration(c.in)
+		if err != nil {
+			t.Errorf("Unexpected error on input %q", c.in)
+		}
+		if time.Duration(d) != c.out {
+			t.Errorf("Expected %v but got %v", c.out, d)
+		}
+		expectedString := c.expectedString
+		if c.expectedString == "" {
+			expectedString = c.in
+		}
+		if d.String() != expectedString {
+			t.Errorf("Expected duration string %q but got %q", c.in, d.String())
+		}
+	}
+
+	for _, c := range casesAllowNegative {
+		d, err := ParseDurationAllowNegative(c.in)
 		if err != nil {
 			t.Errorf("Unexpected error on input %q", c.in)
 		}
@@ -362,7 +389,6 @@ func TestParseBadDuration(t *testing.T) {
 		if err == nil {
 			t.Errorf("Expected error on input %s", c)
 		}
-
 	}
 }
 

--- a/model/time_test.go
+++ b/model/time_test.go
@@ -78,66 +78,84 @@ func TestParseDuration(t *testing.T) {
 			in:             "0",
 			out:            0,
 			expectedString: "0s",
-		}, {
+		},
+		{
 			in:             "0w",
 			out:            0,
 			expectedString: "0s",
-		}, {
+		},
+		{
 			in:  "0s",
 			out: 0,
-		}, {
+		},
+		{
 			in:  "324ms",
 			out: 324 * time.Millisecond,
-		}, {
+		},
+		{
 			in:  "3s",
 			out: 3 * time.Second,
-		}, {
+		},
+		{
 			in:  "5m",
 			out: 5 * time.Minute,
-		}, {
+		},
+		{
 			in:  "1h",
 			out: time.Hour,
-		}, {
+		},
+		{
 			in:  "4d",
 			out: 4 * 24 * time.Hour,
-		}, {
+		},
+		{
 			in:  "4d1h",
 			out: 4*24*time.Hour + time.Hour,
-		}, {
+		},
+		{
 			in:             "14d",
 			out:            14 * 24 * time.Hour,
 			expectedString: "2w",
-		}, {
+		},
+		{
 			in:  "3w",
 			out: 3 * 7 * 24 * time.Hour,
-		}, {
+		},
+		{
 			in:             "3w2d1h",
 			out:            3*7*24*time.Hour + 2*24*time.Hour + time.Hour,
 			expectedString: "23d1h",
-		}, {
+		},
+		{
 			in:  "10y",
 			out: 10 * 365 * 24 * time.Hour,
 		},
 		{
 			in:  "-3s",
 			out: -3 * time.Second,
-		}, {
+		},
+		{
 			in:  "-5m",
 			out: -5 * time.Minute,
-		}, {
+		},
+		{
 			in:  "-1h",
 			out: -1 * time.Hour,
-		}, {
+		},
+		{
 			in:  "-2d",
 			out: -2 * 24 * time.Hour,
-		}, {
+		},
+		{
 			in:  "-1w",
 			out: -7 * 24 * time.Hour,
-		}, {
+		},
+		{
 			in:             "-3w2d1h",
 			out:            -(3*7*24*time.Hour + 2*24*time.Hour + time.Hour),
 			expectedString: "-23d1h",
-		}, {
+		},
+		{
 			in:  "-10y",
 			out: -10 * 365 * 24 * time.Hour,
 		},

--- a/model/time_test.go
+++ b/model/time_test.go
@@ -68,7 +68,6 @@ func TestDuration(t *testing.T) {
 }
 
 func TestParseDuration(t *testing.T) {
-
 	type testCase struct {
 		in              string
 		out             time.Duration


### PR DESCRIPTION
This PR extend the `ParseDuration` function to support negative durations.

negative durations need be useful in Loki alerts templates where time offsets such as '-5m' are common in range calculations and comparisons.

### Changes:
- update `ParseDuration` to handle negative values like `-1h`, `-30m`, etc.
- preserves compatibility with existing valid duration strings.
- includes error checks for unit order and duration overflows.

related to promethes/template changes for Loki alerting - see [prometheus/prometheus#16669](https://github.com/prometheus/prometheus/pull/16619)