### PR TITLE
feat(promslog): add Level() method to get slog.Level

### DIFF
--- a/promslog/slog.go
+++ b/promslog/slog.go
@@ -76,6 +76,11 @@ func (l *Level) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return nil
 }
 
+// Level returns the value of the logging level as an slog.Level.
+func (l *Level) Level() slog.Level {
+	return l.lvl.Level()
+}
+
 // String returns the current level.
 func (l *Level) String() string {
 	switch l.lvl.Level() {


### PR DESCRIPTION
Adds a `Level()` method to the promslog.Level type. We already expose
the configured level with the `String()` method, but only in a
specifically processed format. This means that downstream projects which
need a true `slog.Level` value need to do shenanigans like we do in the
blackbox_exporter here[1]. The slog.Level type is really just an int
behind the scenes, but buys us access to the type's methods, obviously.
If we want to make this a bit more flexible/"future proof", we could
instead have the method return an slog.Leveler interface type. I don't
think it's necessary though, as we'd probably only want to do that if we
intended to expose access to promslog.Level's internal slog.LevelVar
(since that also satisfies the slog.Leveler interface), and I don't
think that's a good idea -- giving direct access would allow users to
interact with the level var directly, providing an avenue to change
level configurations outside of promslog's knowledge, resulting in
unexpected behavior at best and incompatible behavior at worst. I think
providing access to the value of the level as a proper slog.Level value
as done here is useful enough on it's own and the safer option.

1. https://github.com/prometheus/blackbox_exporter/blob/f77c50ed7c0f39b734235931e773cf7b5af1fc8a/prober/handler.go#L236-L249
2. https://pkg.go.dev/log/slog#Level

Signed-off-by: TJ Hoplock <t.hoplock@gmail.com>
