### PR TITLE
Add `ValidationScheme` methods `IsValidMetricName` and `IsValidLabelName`

### DIFF
--- a/expfmt/decode.go
+++ b/expfmt/decode.go
@@ -93,6 +93,7 @@ func (d *protoDecoder) Decode(v *dto.MetricFamily) error {
 	if err := opts.UnmarshalFrom(d.r, v); err != nil {
 		return err
 	}
+	//nolint:staticcheck // model.IsValidMetricName is deprecated.
 	if !model.IsValidMetricName(model.LabelValue(v.GetName())) {
 		return fmt.Errorf("invalid metric name %q", v.GetName())
 	}
@@ -107,6 +108,7 @@ func (d *protoDecoder) Decode(v *dto.MetricFamily) error {
 			if !model.LabelValue(l.GetValue()).IsValid() {
 				return fmt.Errorf("invalid label value %q", l.GetValue())
 			}
+			//nolint:staticcheck // model.LabelName.IsValid is deprecated.
 			if !model.LabelName(l.GetName()).IsValid() {
 				return fmt.Errorf("invalid label name %q", l.GetName())
 			}

--- a/expfmt/openmetrics_create.go
+++ b/expfmt/openmetrics_create.go
@@ -477,7 +477,7 @@ func writeOpenMetricsNameAndLabelPairs(
 	if name != "" {
 		// If the name does not pass the legacy validity check, we must put the
 		// metric name inside the braces, quoted.
-		if !model.IsValidLegacyMetricName(name) {
+		if !model.LegacyValidation.IsValidMetricName(name) {
 			metricInsideBraces = true
 			err := w.WriteByte(separator)
 			written++

--- a/expfmt/text_create.go
+++ b/expfmt/text_create.go
@@ -354,7 +354,7 @@ func writeNameAndLabelPairs(
 	if name != "" {
 		// If the name does not pass the legacy validity check, we must put the
 		// metric name inside the braces.
-		if !model.IsValidLegacyMetricName(name) {
+		if !model.LegacyValidation.IsValidMetricName(name) {
 			metricInsideBraces = true
 			err := w.WriteByte(separator)
 			written++
@@ -498,7 +498,7 @@ func writeInt(w enhancedWriter, i int64) (int, error) {
 // writeName writes a string as-is if it complies with the legacy naming
 // scheme, or escapes it in double quotes if not.
 func writeName(w enhancedWriter, name string) (int, error) {
-	if model.IsValidLegacyMetricName(name) {
+	if model.LegacyValidation.IsValidMetricName(name) {
 		return w.WriteString(name)
 	}
 	var written int

--- a/model/labels.go
+++ b/model/labels.go
@@ -106,34 +106,21 @@ type LabelName string
 // IsValid returns true iff the name matches the pattern of LabelNameRE when
 // NameValidationScheme is set to LegacyValidation, or valid UTF-8 if
 // NameValidationScheme is set to UTF8Validation.
+//
+// Deprecated: This method should not be used and may be removed in the future.
+// Use [ValidationScheme.IsValidLabelName] instead.
 func (ln LabelName) IsValid() bool {
-	if len(ln) == 0 {
-		return false
-	}
-	switch NameValidationScheme {
-	case LegacyValidation:
-		return ln.IsValidLegacy()
-	case UTF8Validation:
-		return utf8.ValidString(string(ln))
-	default:
-		panic(fmt.Sprintf("Invalid name validation scheme requested: %d", NameValidationScheme))
-	}
+	return NameValidationScheme.IsValidLabelName(string(ln))
 }
 
 // IsValidLegacy returns true iff name matches the pattern of LabelNameRE for
 // legacy names. It does not use LabelNameRE for the check but a much faster
 // hardcoded implementation.
+//
+// Deprecated: This method should not be used and may be removed in the future.
+// Use [LegacyValidation.IsValidLabelName] instead.
 func (ln LabelName) IsValidLegacy() bool {
-	if len(ln) == 0 {
-		return false
-	}
-	for i, b := range ln {
-		// TODO: Apply De Morgan's law. Make sure there are tests for this.
-		if !((b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || b == '_' || (b >= '0' && b <= '9' && i > 0)) { //nolint:staticcheck
-			return false
-		}
-	}
-	return true
+	return LegacyValidation.IsValidLabelName(string(ln))
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.

--- a/model/labels_test.go
+++ b/model/labels_test.go
@@ -172,7 +172,7 @@ func TestValidationScheme_IsLabelNameValid(t *testing.T) {
 			}
 			NameValidationScheme = UTF8Validation
 			if labelName.IsValid() != s.utf8Valid {
-				t.Errorf("Expected %v for %q using UTF-8 IsValid method", s.legacyValid, s.ln)
+				t.Errorf("Expected %v for %q using UTF-8 IsValid method", s.utf8Valid, s.ln)
 			}
 		})
 	}

--- a/model/labels_test.go
+++ b/model/labels_test.go
@@ -142,6 +142,11 @@ func TestValidationScheme_IsLabelNameValid(t *testing.T) {
 			legacyValid: false,
 			utf8Valid:   false,
 		},
+		{
+			ln:          "",
+			legacyValid: false,
+			utf8Valid:   false,
+		},
 	}
 	for _, s := range scenarios {
 		t.Run(fmt.Sprintf("%s,%t,%t", s.ln, s.legacyValid, s.utf8Valid), func(t *testing.T) {

--- a/model/metric.go
+++ b/model/metric.go
@@ -144,9 +144,9 @@ func (s ValidationScheme) IsValidMetricName(metricName string) bool {
 		if len(metricName) == 0 {
 			return false
 		}
-		return utf8.ValidString(string(metricName))
+		return utf8.ValidString(metricName)
 	default:
-		panic(fmt.Sprintf("Invalid metricName validation scheme requested: %s", s.String()))
+		panic(fmt.Sprintf("Invalid name validation scheme requested: %s", s.String()))
 	}
 }
 
@@ -168,7 +168,7 @@ func (s ValidationScheme) IsValidLabelName(labelName string) bool {
 		if len(labelName) == 0 {
 			return false
 		}
-		return utf8.ValidString(string(labelName))
+		return utf8.ValidString(labelName)
 	default:
 		panic(fmt.Sprintf("Invalid name validation scheme requested: %s", s))
 	}

--- a/model/metric.go
+++ b/model/metric.go
@@ -152,9 +152,6 @@ func (s ValidationScheme) IsValidMetricName(metricName string) bool {
 
 // IsValidLabelName returns whether labelName is valid according to s.
 func (s ValidationScheme) IsValidLabelName(labelName string) bool {
-	if len(labelName) == 0 {
-		return false
-	}
 	switch s {
 	case LegacyValidation:
 		if len(labelName) == 0 {
@@ -168,6 +165,9 @@ func (s ValidationScheme) IsValidLabelName(labelName string) bool {
 		}
 		return true
 	case UTF8Validation:
+		if len(labelName) == 0 {
+			return false
+		}
 		return utf8.ValidString(string(labelName))
 	default:
 		panic(fmt.Sprintf("Invalid name validation scheme requested: %s", s))

--- a/model/metric_test.go
+++ b/model/metric_test.go
@@ -286,7 +286,7 @@ func TestValidationScheme_IsMetricNameValid(t *testing.T) {
 			}
 			NameValidationScheme = UTF8Validation
 			if IsValidMetricName(LabelValue(s.mn)) != s.utf8Valid {
-				t.Errorf("Expected %v for %q using utf-8 IsValidMetricName method", s.legacyValid, s.mn)
+				t.Errorf("Expected %v for %q using utf-8 IsValidMetricName method", s.utf8Valid, s.mn)
 			}
 		})
 	}


### PR DESCRIPTION
Add `ValidationScheme` method `IsValidMetricName` to replace `model.IsValidMetricName` and `IsValidLegacyMetricName` , and `ValidationScheme` method `IsValidMetricName` to replace `model.LabelName.IsValid` and `model.LabelName.IsValidLegacy`. The replaces functions are marked as deprecated, so to phase out dependency on the `model.NameValidationScheme` global.