### PR TITLE
Fix delimited proto not escaped correctly

### DIFF
--- a/expfmt/encode.go
+++ b/expfmt/encode.go
@@ -153,7 +153,7 @@ func NewEncoder(w io.Writer, format Format, options ...EncoderOption) Encoder {
 	case TypeProtoDelim:
 		return encoderCloser{
 			encode: func(v *dto.MetricFamily) error {
-				_, err := protodelim.MarshalTo(w, v)
+				_, err := protodelim.MarshalTo(w, model.EscapeMetricFamily(v, escapingScheme))
 				return err
 			},
 			close: func() error { return nil },


### PR DESCRIPTION
I have encountered an issue that is blocking me from upgrading Prometheus to 3.x where despite receiving a content type header of `"application/vnd.google.protobuf; proto=io.prometheus.client.MetricFamily; encoding=delimited; escaping=underscores"` I get `.` in metric and label names. 

I've noticed there is possibly a missing call to `EscapeMetricFamily` for delimited proto. 

I also noticed the test `TestEscapedEncode` did not assert that actual escaping is done, so fixed that too.