### PR TITLE
expfmt: Add NewTextParser function

### DIFF
--- a/expfmt/decode.go
+++ b/expfmt/decode.go
@@ -151,7 +151,7 @@ type textDecoder struct {
 func (d *textDecoder) Decode(v *dto.MetricFamily) error {
 	if d.err == nil {
 		// Read all metrics in one shot.
-		p := TextParser{scheme: d.s}
+		p := NewTextParser(d.s)
 		d.fams, d.err = p.TextToMetricFamilies(d.r)
 		// If we don't get an error, store io.EOF for the end.
 		if d.err == nil {

--- a/expfmt/fuzz.go
+++ b/expfmt/fuzz.go
@@ -17,7 +17,11 @@
 
 package expfmt
 
-import "bytes"
+import (
+	"bytes"
+
+	"github.com/prometheus/common/model"
+)
 
 // Fuzz text metric parser with with github.com/dvyukov/go-fuzz:
 //
@@ -26,7 +30,7 @@ import "bytes"
 //
 // Further input samples should go in the folder fuzz/corpus.
 func Fuzz(in []byte) int {
-	parser := TextParser{}
+	parser := NewTextParser(model.UTF8Validation)
 	_, err := parser.TextToMetricFamilies(bytes.NewReader(in))
 
 	if err != nil {

--- a/expfmt/text_parse.go
+++ b/expfmt/text_parse.go
@@ -83,6 +83,11 @@ type TextParser struct {
 	scheme model.ValidationScheme
 }
 
+// NewTextParser returns a new TextParser with the provided nameValidationScheme.
+func NewTextParser(nameValidationScheme model.ValidationScheme) TextParser {
+	return TextParser{scheme: nameValidationScheme}
+}
+
 // TextToMetricFamilies reads 'in' as the simple and flat text-based exchange
 // format and creates MetricFamily proto messages. It returns the MetricFamily
 // proto messages in a map where the metric names are the keys, along with any

--- a/expfmt/text_parse_test.go
+++ b/expfmt/text_parse_test.go
@@ -25,6 +25,23 @@ import (
 	"github.com/prometheus/common/model"
 )
 
+func TestNewTextParser(t *testing.T) {
+	p := NewTextParser(model.UTF8Validation)
+	if p.scheme != model.UTF8Validation {
+		t.Errorf("expected NewTextParser to return a TextParser with scheme %s - got %s", model.UTF8Validation, p.scheme)
+	}
+
+	p = NewTextParser(model.LegacyValidation)
+	if p.scheme != model.LegacyValidation {
+		t.Errorf("expected NewTextParser to return a TextParser with scheme %s - got %s", model.LegacyValidation, p.scheme)
+	}
+
+	p = NewTextParser(model.UnsetValidation)
+	if p.scheme != model.UnsetValidation {
+		t.Errorf("expected NewTextParser to return a TextParser with scheme %s - got %s", model.UnsetValidation, p.scheme)
+	}
+}
+
 func testTextParse(t testing.TB) {
 	scenarios := []struct {
 		in  string
@@ -1001,7 +1018,7 @@ func BenchmarkParseError(b *testing.B) {
 
 func TestTextParserStartOfLine(t *testing.T) {
 	t.Run("EOF", func(t *testing.T) {
-		p := TextParser{}
+		p := NewTextParser(model.UTF8Validation)
 		in := strings.NewReader("")
 		p.reset(in)
 		fn := p.startOfLine()
@@ -1014,7 +1031,7 @@ func TestTextParserStartOfLine(t *testing.T) {
 	})
 
 	t.Run("OtherError", func(t *testing.T) {
-		p := TextParser{}
+		p := NewTextParser(model.UTF8Validation)
 		in := &errReader{err: errors.New("unexpected error")}
 		p.reset(in)
 		fn := p.startOfLine()


### PR DESCRIPTION
Add `expfmt.NewTextParser` function that allows providing name validation scheme. I think this was an omission in #808, since it added the in practice mandatory `expfmt.TextParser.scheme` field ("Defaults to the invalid UnsetValidation"), but provides no way for clients outside of the `expfmt` package to configure it. Through `expfmt.NewTextParser`, `prometheus/common` clients can safely create `expfmt.TextParser`s with a valid name validation scheme.

I'm also including a test for `NewTextParser`.