### PR TITLE
Enable revive rules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -148,7 +148,7 @@ linters:
           arguments:
             - "preserveScope"
         - name: time-naming
-        #- name: unexported-return
+        - name: unexported-return
         - name: unreachable-code
         - name: unused-parameter
           severity: warning

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -153,7 +153,7 @@ linters:
         - name: unused-parameter
           severity: warning
           disabled: true
-        #- name: unused-receiver
+        - name: unused-receiver
         #- name: var-declaration
         #- name: var-naming
     testifylint:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -134,10 +134,10 @@ linters:
         - name: error-strings
         - name: errorf
         - name: exported
-        #- name: increment-decrement
-        #- name: indent-error-flow
-        #  arguments:
-        #    - "preserveScope"
+        - name: increment-decrement
+        - name: indent-error-flow
+          arguments:
+            - "preserveScope"
         - name: package-comments
           # TODO(beorn7): Currently, we have a lot of missing package doc comments. Maybe we should have them.
           disabled: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -154,7 +154,7 @@ linters:
           severity: warning
           disabled: true
         - name: unused-receiver
-        #- name: var-declaration
+        - name: var-declaration
         #- name: var-naming
     testifylint:
       enable-all: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -142,7 +142,7 @@ linters:
           # TODO(beorn7): Currently, we have a lot of missing package doc comments. Maybe we should have them.
           disabled: true
         - name: range
-        #- name: receiver-naming
+        - name: receiver-naming
         - name: redefines-builtin-id
         - name: superfluous-else
           arguments:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -121,10 +121,10 @@ linters:
             # Allow functions with test or bench signatures.
             - allowTypesBefore: '*testing.T,testing.TB'
         - name: context-keys-type
-        #- name: dot-imports
-        #- name: early-return
-        #  arguments:
-        #    - "preserveScope"
+        - name: dot-imports
+        - name: early-return
+          arguments:
+            - "preserveScope"
         # A lot of false positives: incorrectly identifies channel draining as "empty code block".
         # See https://github.com/mgechev/revive/issues/386
         - name: empty-block
@@ -133,7 +133,7 @@ linters:
         - name: error-return
         - name: error-strings
         - name: errorf
-        #- name: exported
+        - name: exported
         #- name: increment-decrement
         #- name: indent-error-flow
         #  arguments:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -155,7 +155,7 @@ linters:
           disabled: true
         - name: unused-receiver
         - name: var-declaration
-        #- name: var-naming
+        - name: var-naming
     testifylint:
       enable-all: true
       disable:

--- a/config/config.go
+++ b/config/config.go
@@ -30,7 +30,7 @@ type Secret string
 // MarshalSecretValue if set to true will expose Secret type
 // through the marshal interfaces. Useful for outside projects
 // that load and marshal the Prometheus config.
-var MarshalSecretValue bool = false
+var MarshalSecretValue = false
 
 // MarshalYAML implements the yaml.Marshaler interface for Secrets.
 func (s Secret) MarshalYAML() (interface{}, error) {

--- a/config/http_config.go
+++ b/config/http_config.go
@@ -732,11 +732,11 @@ func (s *InlineSecret) Fetch(context.Context) (string, error) {
 	return s.text, nil
 }
 
-func (s *InlineSecret) Description() string {
+func (*InlineSecret) Description() string {
 	return "inline"
 }
 
-func (s *InlineSecret) Immutable() bool {
+func (*InlineSecret) Immutable() bool {
 	return true
 }
 
@@ -760,7 +760,7 @@ func (s *FileSecret) Description() string {
 	return "file " + s.file
 }
 
-func (s *FileSecret) Immutable() bool {
+func (*FileSecret) Immutable() bool {
 	return false
 }
 
@@ -778,7 +778,7 @@ func (s *refSecret) Description() string {
 	return "ref " + s.ref
 }
 
-func (s *refSecret) Immutable() bool {
+func (*refSecret) Immutable() bool {
 	return false
 }
 

--- a/config/http_config.go
+++ b/config/http_config.go
@@ -542,8 +542,14 @@ func (s *secretManagerOption) applyToTLSConfigOptions(opts *tlsConfigOptions) {
 	opts.secretManager = s.secretManager
 }
 
+// SecretManagerOption is an option for providing a SecretManager.
+type SecretManagerOption interface {
+	TLSConfigOption
+	HTTPClientOption
+}
+
 // WithSecretManager allows setting the secret manager.
-func WithSecretManager(manager SecretManager) *secretManagerOption {
+func WithSecretManager(manager SecretManager) SecretManagerOption {
 	return &secretManagerOption{
 		secretManager: manager,
 	}

--- a/config/http_config.go
+++ b/config/http_config.go
@@ -346,7 +346,7 @@ func nonZeroCount[T comparable](values ...T) int {
 	var zero T
 	for _, value := range values {
 		if value != zero {
-			count += 1
+			count++
 		}
 	}
 	return count

--- a/expfmt/expfmt.go
+++ b/expfmt/expfmt.go
@@ -36,9 +36,11 @@ const (
 	ProtoType     = `application/vnd.google.protobuf`
 	ProtoProtocol = `io.prometheus.client.MetricFamily`
 	// Deprecated: Use expfmt.NewFormat(expfmt.TypeProtoCompact) instead.
-	ProtoFmt                 = ProtoType + "; proto=" + ProtoProtocol + ";"
-	OpenMetricsType          = `application/openmetrics-text`
+	ProtoFmt        = ProtoType + "; proto=" + ProtoProtocol + ";"
+	OpenMetricsType = `application/openmetrics-text`
+	//nolint:revive // Allow for underscores.
 	OpenMetricsVersion_0_0_1 = "0.0.1"
+	//nolint:revive // Allow for underscores.
 	OpenMetricsVersion_1_0_0 = "1.0.0"
 
 	// The Content-Type values for the different wire protocols. Do not do direct
@@ -54,8 +56,10 @@ const (
 	// Deprecated: Use expfmt.NewFormat(expfmt.TypeProtoCompact) instead.
 	FmtProtoCompact Format = ProtoFmt + ` encoding=compact-text`
 	// Deprecated: Use expfmt.NewFormat(expfmt.TypeOpenMetrics) instead.
+	//nolint:revive // Allow for underscores.
 	FmtOpenMetrics_1_0_0 Format = OpenMetricsType + `; version=` + OpenMetricsVersion_1_0_0 + `; charset=utf-8`
 	// Deprecated: Use expfmt.NewFormat(expfmt.TypeOpenMetrics) instead.
+	//nolint:revive // Allow for underscores.
 	FmtOpenMetrics_0_0_1 Format = OpenMetricsType + `; version=` + OpenMetricsVersion_0_0_1 + `; charset=utf-8`
 )
 

--- a/expfmt/expfmt.go
+++ b/expfmt/expfmt.go
@@ -188,8 +188,8 @@ func (f Format) FormatType() FormatType {
 // Format contains a escaping=allow-utf-8 term, it will select NoEscaping. If a valid
 // "escaping" term exists, that will be used. Otherwise, the global default will
 // be returned.
-func (format Format) ToEscapingScheme() model.EscapingScheme {
-	for _, p := range strings.Split(string(format), ";") {
+func (f Format) ToEscapingScheme() model.EscapingScheme {
+	for _, p := range strings.Split(string(f), ";") {
 		toks := strings.Split(p, "=")
 		if len(toks) != 2 {
 			continue

--- a/expfmt/text_parse.go
+++ b/expfmt/text_parse.go
@@ -381,13 +381,12 @@ func (p *TextParser) startLabelName() stateFn {
 	labels := make(map[string]struct{})
 	for _, l := range p.currentLabelPairs {
 		lName := l.GetName()
-		if _, exists := labels[lName]; !exists {
-			labels[lName] = struct{}{}
-		} else {
+		if _, exists := labels[lName]; exists {
 			p.parseError(fmt.Sprintf("duplicate label names for metric %q", p.currentMF.GetName()))
 			p.currentLabelPairs = nil
 			return nil
 		}
+		labels[lName] = struct{}{}
 	}
 	return p.startLabelValue
 }

--- a/model/labelset.go
+++ b/model/labelset.go
@@ -114,10 +114,10 @@ func (ls LabelSet) Clone() LabelSet {
 }
 
 // Merge is a helper function to non-destructively merge two label sets.
-func (l LabelSet) Merge(other LabelSet) LabelSet {
-	result := make(LabelSet, len(l))
+func (ls LabelSet) Merge(other LabelSet) LabelSet {
+	result := make(LabelSet, len(ls))
 
-	for k, v := range l {
+	for k, v := range ls {
 		result[k] = v
 	}
 
@@ -140,7 +140,7 @@ func (ls LabelSet) FastFingerprint() Fingerprint {
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface.
-func (l *LabelSet) UnmarshalJSON(b []byte) error {
+func (ls *LabelSet) UnmarshalJSON(b []byte) error {
 	var m map[LabelName]LabelValue
 	if err := json.Unmarshal(b, &m); err != nil {
 		return err
@@ -153,6 +153,6 @@ func (l *LabelSet) UnmarshalJSON(b []byte) error {
 			return fmt.Errorf("%q is not a valid label name", ln)
 		}
 	}
-	*l = LabelSet(m)
+	*ls = LabelSet(m)
 	return nil
 }

--- a/model/metric.go
+++ b/model/metric.go
@@ -205,7 +205,7 @@ func (s ValidationScheme) IsValidLabelName(labelName string) bool {
 }
 
 // Type implements the pflag.Value interface.
-func (s ValidationScheme) Type() string {
+func (ValidationScheme) Type() string {
 	return "validationScheme"
 }
 

--- a/model/time.go
+++ b/model/time.go
@@ -178,7 +178,7 @@ func (d *Duration) Set(s string) error {
 }
 
 // Type implements pflag.Value.
-func (d *Duration) Type() string {
+func (*Duration) Type() string {
 	return "duration"
 }
 

--- a/model/value.go
+++ b/model/value.go
@@ -350,9 +350,9 @@ func (m Matrix) Len() int           { return len(m) }
 func (m Matrix) Less(i, j int) bool { return m[i].Metric.Before(m[j].Metric) }
 func (m Matrix) Swap(i, j int)      { m[i], m[j] = m[j], m[i] }
 
-func (mat Matrix) String() string {
-	matCp := make(Matrix, len(mat))
-	copy(matCp, mat)
+func (m Matrix) String() string {
+	matCp := make(Matrix, len(m))
+	copy(matCp, m)
 	sort.Sort(matCp)
 
 	strs := make([]string, len(matCp))

--- a/model/value_histogram.go
+++ b/model/value_histogram.go
@@ -86,22 +86,22 @@ func (s *HistogramBucket) Equal(o *HistogramBucket) bool {
 	return s == o || (s.Boundaries == o.Boundaries && s.Lower == o.Lower && s.Upper == o.Upper && s.Count == o.Count)
 }
 
-func (b HistogramBucket) String() string {
+func (s HistogramBucket) String() string {
 	var sb strings.Builder
-	lowerInclusive := b.Boundaries == 1 || b.Boundaries == 3
-	upperInclusive := b.Boundaries == 0 || b.Boundaries == 3
+	lowerInclusive := s.Boundaries == 1 || s.Boundaries == 3
+	upperInclusive := s.Boundaries == 0 || s.Boundaries == 3
 	if lowerInclusive {
 		sb.WriteRune('[')
 	} else {
 		sb.WriteRune('(')
 	}
-	fmt.Fprintf(&sb, "%g,%g", b.Lower, b.Upper)
+	fmt.Fprintf(&sb, "%g,%g", s.Lower, s.Upper)
 	if upperInclusive {
 		sb.WriteRune(']')
 	} else {
 		sb.WriteRune(')')
 	}
-	fmt.Fprintf(&sb, ":%v", b.Count)
+	fmt.Fprintf(&sb, ":%v", s.Count)
 	return sb.String()
 }
 

--- a/model/value_type.go
+++ b/model/value_type.go
@@ -66,8 +66,8 @@ func (et *ValueType) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-func (e ValueType) String() string {
-	switch e {
+func (et ValueType) String() string {
+	switch et {
 	case ValNone:
 		return "<ValNone>"
 	case ValScalar:

--- a/server/static_file_server_test.go
+++ b/server/static_file_server_test.go
@@ -23,7 +23,7 @@ import (
 
 type dummyFileSystem struct{}
 
-func (fs dummyFileSystem) Open(path string) (http.File, error) {
+func (dummyFileSystem) Open(path string) (http.File, error) {
 	return http.Dir(".").Open(".")
 }
 


### PR DESCRIPTION
Enable previously disabled revive rules, to harmonize with Prometheus:
* dot-imports
* early-return 
* exported
* increment-decrement
* indent-error-flow
* receiver-naming
* unexported-return
* unused-receiver
* var-declaration
* var-naming

Also fixing caught issues.

