### PR TITLE
Use go.uber.org/atomic instead of sync/atomic

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -66,8 +66,8 @@ linters:
       rules:
         main:
           deny:
-            #- pkg: "sync/atomic"
-              #desc: "Use go.uber.org/atomic instead of sync/atomic"
+            - pkg: "sync/atomic"
+              desc: "Use go.uber.org/atomic instead of sync/atomic"
             - pkg: "github.com/go-kit/kit/log"
               desc: "Use github.com/go-kit/log instead of github.com/go-kit/kit/log"
             - pkg: "io/ioutil"

--- a/config/http_config_test.go
+++ b/config/http_config_test.go
@@ -31,11 +31,11 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 	"gopkg.in/yaml.v2"
 )
 
@@ -1309,7 +1309,8 @@ func TestTLSRoundTripperRaces(t *testing.T) {
 
 	var wg sync.WaitGroup
 	ch := make(chan struct{})
-	var total, ok int64
+	total := atomic.NewInt64(0)
+	ok := atomic.NewInt64(0)
 	// Spawn 10 Go routines polling the server concurrently.
 	for i := 0; i < 10; i++ {
 		wg.Add(1)
@@ -1320,11 +1321,11 @@ func TestTLSRoundTripperRaces(t *testing.T) {
 				case <-ch:
 					return
 				default:
-					atomic.AddInt64(&total, 1)
+					total.Add(1)
 					r, err := c.Get(testServer.URL)
 					if err == nil {
 						r.Body.Close()
-						atomic.AddInt64(&ok, 1)
+						ok.Add(1)
 					}
 				}
 			}

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f
 	github.com/prometheus/client_model v0.6.2
 	github.com/stretchr/testify v1.10.0
+	go.uber.org/atomic v1.11.0
 	golang.org/x/net v0.42.0
 	golang.org/x/oauth2 v0.30.0
 	google.golang.org/protobuf v1.36.6

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/xhit/go-str2duration/v2 v2.1.0 h1:lxklc02Drh6ynqX+DdPyp5pCKLUQpRT8bp8Ydu2Bstc=
 github.com/xhit/go-str2duration/v2 v2.1.0/go.mod h1:ohY8p+0f07DiV6Em5LKB0s2YpLtXVyJfNt1+BlmyAsU=
+go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
+go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 golang.org/x/net v0.42.0 h1:jzkYrhi3YQWD6MLBJcsklgQsoAcw89EcZbJw8Z614hs=
 golang.org/x/net v0.42.0/go.mod h1:FF1RA5d3u7nAYA4z2TkclSCKh68eSXtiFwcWQpPXdt8=
 golang.org/x/oauth2 v0.30.0 h1:dnDm7JmhM45NNpd8FDDeLhK6FwqbOf4MLCM9zb1BOHI=


### PR DESCRIPTION
Use `go.uber.org/atomic` instead of `sync/atomic`.