### PR TITLE
Add pre-allocation to EscapeMetricFamily

### DIFF
--- a/model/metric.go
+++ b/model/metric.go
@@ -429,6 +429,7 @@ func EscapeName(name string, scheme EscapingScheme) string {
 		if IsValidLegacyMetricName(name) {
 			return name
 		}
+		escaped.Grow(len(name))
 		for i, b := range name {
 			if isValidLegacyRune(b, i) {
 				escaped.WriteRune(b)


### PR DESCRIPTION
Good day,

While I was checking some profiles I noticed that `EscapeName` and `EscapeMetricFamily` where doing a lot of allocation.
This PR reduce this a little by pre-allocating the `Metric` and `Label` slices and the string builder for the `UnderscoreEscaping` strategy in `EscapeName`.

Thanks for reviewing and let me know what you think.
Have a good one!

<img width="2221" height="622" alt="2025-09-02_12-08" src="https://github.com/user-attachments/assets/9e28a1c5-b7e6-4e1f-bcdb-c7e7c21296ac" />
