### PR TITLE
Revert "Use github.com/grafana/regexp instead of regexp"

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -72,8 +72,6 @@ linters:
               desc: "Use github.com/go-kit/log instead of github.com/go-kit/kit/log"
             - pkg: "io/ioutil"
               desc: "Use corresponding 'os' or 'io' functions instead."
-            - pkg: "regexp"
-              desc: "Use github.com/grafana/regexp instead of regexp"
             - pkg: "github.com/pkg/errors"
               desc: "Use 'errors' or 'fmt' instead of github.com/pkg/errors"
             - pkg: "gzip"

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ toolchain go1.24.1
 require (
 	github.com/alecthomas/kingpin/v2 v2.4.0
 	github.com/google/go-cmp v0.7.0
-	github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc h1:GN2Lv3MGO7AS6PrRoT6yV5+wkrOpcszoIsO4+4ds248=
-github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc/go.mod h1:+JKpmjMGhpgPL+rXZ5nsZieVzvarn86asRlBg4uNGnk=
 github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2EA=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=

--- a/model/labels.go
+++ b/model/labels.go
@@ -16,10 +16,9 @@ package model
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
 	"unicode/utf8"
-
-	"github.com/grafana/regexp"
 )
 
 const (

--- a/model/metric.go
+++ b/model/metric.go
@@ -17,12 +17,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
 	"unicode/utf8"
 
-	"github.com/grafana/regexp"
 	dto "github.com/prometheus/client_model/go"
 	"google.golang.org/protobuf/proto"
 	"gopkg.in/yaml.v2"

--- a/model/silence.go
+++ b/model/silence.go
@@ -17,9 +17,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
 	"time"
-
-	"github.com/grafana/regexp"
 )
 
 // Matcher describes a matches the value of a given label.

--- a/model/value_histogram_test.go
+++ b/model/value_histogram_test.go
@@ -16,9 +16,9 @@ package model
 import (
 	"encoding/json"
 	"reflect"
+	"regexp"
 	"testing"
 
-	"github.com/grafana/regexp"
 	"github.com/stretchr/testify/require"
 )
 

--- a/promslog/slog_test.go
+++ b/promslog/slog_test.go
@@ -18,11 +18,11 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/grafana/regexp"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
 )


### PR DESCRIPTION
Revert my change to use the more performant grafana/regexp, as this library shouldn't control this choice. Fixes #836.
This reverts commit 149efd6d704a94178a9123536aabadcf01a6b09a.