### PR TITLE
Revert "Use go.uber.org/atomic instead of sync/atomic (#825)"

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -66,8 +66,6 @@ linters:
       rules:
         main:
           deny:
-            - pkg: "sync/atomic"
-              desc: "Use go.uber.org/atomic instead of sync/atomic"
             - pkg: "github.com/go-kit/kit/log"
               desc: "Use github.com/go-kit/log instead of github.com/go-kit/kit/log"
             - pkg: "io/ioutil"

--- a/config/http_config_test.go
+++ b/config/http_config_test.go
@@ -31,11 +31,11 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 	"go.yaml.in/yaml/v2"
 )
 
@@ -1309,8 +1309,7 @@ func TestTLSRoundTripperRaces(t *testing.T) {
 
 	var wg sync.WaitGroup
 	ch := make(chan struct{})
-	total := atomic.NewInt64(0)
-	ok := atomic.NewInt64(0)
+	var total, ok int64
 	// Spawn 10 Go routines polling the server concurrently.
 	for i := 0; i < 10; i++ {
 		wg.Add(1)
@@ -1321,11 +1320,11 @@ func TestTLSRoundTripperRaces(t *testing.T) {
 				case <-ch:
 					return
 				default:
-					total.Add(1)
+					atomic.AddInt64(&total, 1)
 					r, err := c.Get(testServer.URL)
 					if err == nil {
 						r.Body.Close()
-						ok.Add(1)
+						atomic.AddInt64(&ok, 1)
 					}
 				}
 			}

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f
 	github.com/prometheus/client_model v0.6.2
 	github.com/stretchr/testify v1.11.1
-	go.uber.org/atomic v1.11.0
 	go.yaml.in/yaml/v2 v2.4.2
 	golang.org/x/net v0.43.0
 	golang.org/x/oauth2 v0.30.0

--- a/go.sum
+++ b/go.sum
@@ -43,8 +43,6 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/xhit/go-str2duration/v2 v2.1.0 h1:lxklc02Drh6ynqX+DdPyp5pCKLUQpRT8bp8Ydu2Bstc=
 github.com/xhit/go-str2duration/v2 v2.1.0/go.mod h1:ohY8p+0f07DiV6Em5LKB0s2YpLtXVyJfNt1+BlmyAsU=
-go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
-go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go.yaml.in/yaml/v2 v2.4.2 h1:DzmwEr2rDGHl7lsFgAHxmNz/1NlQ7xLIrlN2h5d1eGI=
 go.yaml.in/yaml/v2 v2.4.2/go.mod h1:081UH+NErpNdqlCXm3TtEran0rJZGxAYx9hb/ELlsPU=
 golang.org/x/net v0.43.0 h1:lat02VYK2j4aLzMzecihNvTlJNQUq316m2Mr9rnM6YE=


### PR DESCRIPTION
Revert my change to use the more performant `go.uber.org/atomic` instead of `sync/atomic`, as this library shouldn't control this choice. Fixes #837.

This reverts commit 6d40fe16ed5f8f21fae8f9e53fd8b54eb08c2d44.