### PR TITLE
Move interface assertions to a test file

### DIFF
--- a/model/metric.go
+++ b/model/metric.go
@@ -24,7 +24,6 @@ import (
 	"unicode/utf8"
 
 	dto "github.com/prometheus/client_model/go"
-	"go.yaml.in/yaml/v2"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -77,14 +76,6 @@ const (
 	// strings.
 	UTF8Validation
 )
-
-var _ interface {
-	yaml.Marshaler
-	yaml.Unmarshaler
-	json.Marshaler
-	json.Unmarshaler
-	fmt.Stringer
-} = new(ValidationScheme)
 
 // String returns the string representation of s.
 func (s ValidationScheme) String() string {

--- a/model/metric_test.go
+++ b/model/metric_test.go
@@ -28,6 +28,14 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+var _ interface {
+	yaml.Marshaler
+	yaml.Unmarshaler
+	json.Marshaler
+	json.Unmarshaler
+	fmt.Stringer
+} = new(ValidationScheme)
+
 func testMetric(t testing.TB) {
 	scenarios := []struct {
 		input           LabelSet


### PR DESCRIPTION
This is the only dependency on YAML in the model package. Moving it to the tests avoids pulling a dependency into the main module of applications that don't otherwise use YAML.