### PR TITLE
chore: 'omitempty' to Oauth2 fields with type Secret to avoid requiring them

### DIFF
--- a/config/http_config.go
+++ b/config/http_config.go
@@ -239,13 +239,13 @@ func (u URL) MarshalJSON() ([]byte, error) {
 // OAuth2 is the oauth2 client configuration.
 type OAuth2 struct {
 	ClientID         string `yaml:"client_id" json:"client_id"`
-	ClientSecret     Secret `yaml:"client_secret" json:"client_secret"`
+	ClientSecret     Secret `yaml:"client_secret,omitempty" json:"client_secret,omitempty"`
 	ClientSecretFile string `yaml:"client_secret_file" json:"client_secret_file"`
 	// ClientSecretRef is the name of the secret within the secret manager to use as the client
 	// secret.
 	ClientSecretRef          string `yaml:"client_secret_ref" json:"client_secret_ref"`
 	ClientCertificateKeyID   string `yaml:"client_certificate_key_id" json:"client_certificate_key_id"`
-	ClientCertificateKey     Secret `yaml:"client_certificate_key" json:"client_certificate_key"`
+	ClientCertificateKey     Secret `yaml:"client_certificate_key,omitempty" json:"client_certificate_key,omitempty"`
 	ClientCertificateKeyFile string `yaml:"client_certificate_key_file" json:"client_certificate_key_file"`
 	// ClientCertificateKeyRef is the name of the secret within the secret manager to use as the client
 	// secret.


### PR DESCRIPTION
After the PR supporting the RFC7523, there are 2 fields with Secret type inside the Oauth2 struct. This isn't a problem at all, but there are some yaml marshalers in other projects using this pkg (I've discovered this bumping the dep in [otel-collector](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/d60cd9f5cca4689dcaf78ee8275a6cda38b5366b/receiver/prometheusreceiver/config.go#L189-L194)) and they can fail during the marshaling process because one (or more of them) can be empty and it's trying to execute custom marshal logic.

Probably the best option should be handling the case everywhere where custom logic is applied, but it's also true that adding omitempty tag in the source solves it for any usecase.

I've tested this change directly there and it works perfectly