### PR TITLE
Update for Go 1.26

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,106 +1,33 @@
 ---
+# Prometheus has switched to GitHub action.
+# Circle CI is not disabled repository-wise so that previous pull requests
+# continue working.
+# This file does not generate any CircleCI workflow.
+
 version: 2.1
 
-orbs:
-  go: circleci/go@1.7.1
+executors:
+  golang:
+    docker:
+      - image: busybox
 
 jobs:
-  test:
-    parameters:
-      go_version:
-        type: string
-      use_gomod_cache:
-        type: boolean
-        default: true
-    docker:
-      - image: cimg/go:<< parameters.go_version >>
-    environment:
-      # Override Go 1.18 security deprecations.
-      GODEBUG: "x509sha1=1,tls10default=1"
+  noopjob:
+    executor: golang
+
     steps:
-      - checkout
-      - when:
-          condition: << parameters.use_gomod_cache >>
-          steps:
-            - go/load-cache:
-                key: v1-go<< parameters.go_version >>
-      - run: make test
-      - when:
-          condition: << parameters.use_gomod_cache >>
-          steps:
-            - go/save-cache:
-                key: v1-go<< parameters.go_version >>
-      - store_test_results:
-          path: test-results
-  test-assets:
-    parameters:
-      go_version:
-        type: string
-      use_gomod_cache:
-        type: boolean
-        default: true
-    docker:
-      - image: cimg/go:<< parameters.go_version >>
-    steps:
-      - checkout
-      - when:
-          condition: << parameters.use_gomod_cache >>
-          steps:
-            - go/load-cache:
-                key: v1-go<< parameters.go_version >>
-      - run: make -C assets test
-      - when:
-          condition: << parameters.use_gomod_cache >>
-          steps:
-            - go/save-cache:
-                key: v1-go<< parameters.go_version >>
-      - store_test_results:
-          path: test-results
-  style:
-    parameters:
-      go_version:
-        type: string
-      use_gomod_cache:
-        type: boolean
-        default: true
-    docker:
-      - image: cimg/go:<< parameters.go_version >>
-    steps:
-      - checkout
-      - when:
-          condition: << parameters.use_gomod_cache >>
-          steps:
-            - go/load-cache:
-                key: v1-go<< parameters.go_version >>
-      - run: make style
-      - run: make -C assets style
-      - run: make check-go-mod-version
-      - when:
-          condition: << parameters.use_gomod_cache >>
-          steps:
-            - go/save-cache:
-                key: v1-go<< parameters.go_version >>
-      - store_test_results:
-          path: test-results
+      - run:
+          command: "true"
 
 workflows:
   version: 2
-  tests:
+  common:
     jobs:
-      # Supported Go versions are synced with github.com/prometheus/client_golang.
-      - test:
-          name: go-<< matrix.go_version >>
-          matrix:
-            parameters:
-              go_version:
-                - "1.24"
-                - "1.25"
-      - test-assets:
-          name: assets-go-<< matrix.go_version >>
-          matrix:
-            parameters:
-              go_version:
-                - "1.25"
-      - style:
-          name: style
-          go_version: "1.25"
+      - noopjob
+    triggers:
+      - schedule:
+          cron: "0 0 30 2 *"
+          filters:
+            branches:
+              only:
+                - master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: CI
+on:
+  pull_request:
+  push:
+    branches: [main, 'release-*']
+    tags: ['v*']
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Install Go
+        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        with:
+          go-version: 1.26.x
+      - run: make check_license
+      - run: make style
+      - run: make -C assets style
+      - run: make check-go-mod-version
+
+  test-assets:
+    name: Test Assets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Install Go
+        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        with:
+          go-version: 1.26.x
+      - run: make -C assets test
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    env:
+      # Override Go 1.18 security deprecations.
+      GODEBUG: "x509sha1=1,tls10default=1"
+    strategy:
+      matrix:
+        go:
+          - 1.25.x
+          - 1.26.x
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Install Go
+        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        with:
+          go-version: ${{ matrix.go }}
+      - run: make test

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -3,6 +3,7 @@
 name: golangci-lint
 on:
   push:
+    branches: [main, master, 'release-*']
     paths:
       - "go.sum"
       - "go.mod"
@@ -10,6 +11,7 @@ on:
       - "scripts/errcheck_excludes.txt"
       - ".github/workflows/golangci-lint.yml"
       - ".golangci.yml"
+    tags: ['v*']
   pull_request:
 
 permissions:  # added using https://github.com/step-security/secure-repo
@@ -24,13 +26,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Install Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
       - name: Install snmp_exporter/generator dependencies
         run: sudo apt-get update && sudo apt-get -y install libsnmp-dev
         if: github.repository == 'prometheus/snmp_exporter'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -133,6 +133,11 @@ linters:
         - name: unused-receiver
         - name: var-declaration
         - name: var-naming
+          # TODO(SuperQ): See: https://github.com/prometheus/prometheus/issues/17766
+          arguments:
+            - []
+            - []
+            - - skip-package-name-checks: true
     testifylint:
       enable-all: true
       disable:

--- a/Makefile.common
+++ b/Makefile.common
@@ -55,13 +55,13 @@ ifneq ($(shell command -v gotestsum 2> /dev/null),)
 endif
 endif
 
-PROMU_VERSION ?= 0.17.0
+PROMU_VERSION ?= 0.18.0
 PROMU_URL     := https://github.com/prometheus/promu/releases/download/v$(PROMU_VERSION)/promu-$(PROMU_VERSION).$(GO_BUILD_PLATFORM).tar.gz
 
 SKIP_GOLANGCI_LINT :=
 GOLANGCI_LINT :=
 GOLANGCI_LINT_OPTS ?=
-GOLANGCI_LINT_VERSION ?= v2.7.2
+GOLANGCI_LINT_VERSION ?= v2.10.1
 GOLANGCI_FMT_OPTS ?=
 # golangci-lint only supports linux, darwin and windows platforms on i386/amd64/arm64.
 # windows isn't included here because of the path separator being different.
@@ -108,6 +108,24 @@ endif
 
 # Build variant:dockerfile pairs for shell iteration.
 DOCKERFILE_VARIANTS_WITH_NAMES := $(foreach df,$(DOCKERFILE_VARIANTS),$(call dockerfile_variant,$(df)):$(df))
+
+# Shell helper to check whether a dockerfile/arch pair is excluded.
+define dockerfile_arch_is_excluded
+case " $(DOCKERFILE_ARCH_EXCLUSIONS) " in \
+	*" $$dockerfile:$(1) "*) true ;; \
+	*) false ;; \
+esac
+endef
+
+# Shell helper to check whether a registry/arch pair is excluded.
+# Extracts registry from DOCKER_REPO (e.g., quay.io/prometheus -> quay.io)
+define registry_arch_is_excluded
+registry=$$(echo "$(DOCKER_REPO)" | cut -d'/' -f1); \
+case " $(DOCKER_REGISTRY_ARCH_EXCLUSIONS) " in \
+	*" $$registry:$(1) "*) true ;; \
+	*) false ;; \
+esac
+endef
 
 BUILD_DOCKER_ARCHS = $(addprefix common-docker-,$(DOCKER_ARCHS))
 PUBLISH_DOCKER_ARCHS = $(addprefix common-docker-publish-,$(DOCKER_ARCHS))
@@ -250,6 +268,10 @@ $(BUILD_DOCKER_ARCHS): common-docker-%:
 	@for variant in $(DOCKERFILE_VARIANTS_WITH_NAMES); do \
 		dockerfile=$${variant#*:}; \
 		variant_name=$${variant%%:*}; \
+		if $(call dockerfile_arch_is_excluded,$*); then \
+			echo "Skipping $$variant_name variant for linux-$* (excluded by DOCKERFILE_ARCH_EXCLUSIONS)"; \
+			continue; \
+		fi; \
 		distroless_arch="$*"; \
 		if [ "$*" = "armv7" ]; then \
 			distroless_arch="arm"; \
@@ -284,6 +306,14 @@ $(PUBLISH_DOCKER_ARCHS): common-docker-publish-%:
 	@for variant in $(DOCKERFILE_VARIANTS_WITH_NAMES); do \
 		dockerfile=$${variant#*:}; \
 		variant_name=$${variant%%:*}; \
+		if $(call dockerfile_arch_is_excluded,$*); then \
+			echo "Skipping push for $$variant_name variant on linux-$* (excluded by DOCKERFILE_ARCH_EXCLUSIONS)"; \
+			continue; \
+		fi; \
+		if $(call registry_arch_is_excluded,$*); then \
+			echo "Skipping push for $$variant_name variant on linux-$* to $(DOCKER_REPO) (excluded by DOCKER_REGISTRY_ARCH_EXCLUSIONS)"; \
+			continue; \
+		fi; \
 		if [ "$$dockerfile" != "Dockerfile" ] || [ "$$variant_name" != "default" ]; then \
 			echo "Pushing $$variant_name variant for linux-$*"; \
 			docker push "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$*:$(SANITIZED_DOCKER_IMAGE_TAG)-$$variant_name"; \
@@ -311,6 +341,14 @@ $(TAG_DOCKER_ARCHS): common-docker-tag-latest-%:
 	@for variant in $(DOCKERFILE_VARIANTS_WITH_NAMES); do \
 		dockerfile=$${variant#*:}; \
 		variant_name=$${variant%%:*}; \
+		if $(call dockerfile_arch_is_excluded,$*); then \
+			echo "Skipping tag for $$variant_name variant on linux-$* (excluded by DOCKERFILE_ARCH_EXCLUSIONS)"; \
+			continue; \
+		fi; \
+		if $(call registry_arch_is_excluded,$*); then \
+			echo "Skipping tag for $$variant_name variant on linux-$* for $(DOCKER_REPO) (excluded by DOCKER_REGISTRY_ARCH_EXCLUSIONS)"; \
+			continue; \
+		fi; \
 		if [ "$$dockerfile" != "Dockerfile" ] || [ "$$variant_name" != "default" ]; then \
 			echo "Tagging $$variant_name variant for linux-$* as latest"; \
 			docker tag "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$*:$(SANITIZED_DOCKER_IMAGE_TAG)-$$variant_name" "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$*:latest-$$variant_name"; \
@@ -330,23 +368,87 @@ common-docker-manifest:
 		variant_name=$${variant%%:*}; \
 		if [ "$$dockerfile" != "Dockerfile" ] || [ "$$variant_name" != "default" ]; then \
 			echo "Creating manifest for $$variant_name variant"; \
-			DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create -a "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):$(SANITIZED_DOCKER_IMAGE_TAG)-$$variant_name" $(foreach ARCH,$(DOCKER_ARCHS),$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$(ARCH):$(SANITIZED_DOCKER_IMAGE_TAG)-$$variant_name); \
+			refs=""; \
+			for arch in $(DOCKER_ARCHS); do \
+				if $(call dockerfile_arch_is_excluded,$$arch); then \
+					echo "  Skipping $$arch for $$variant_name (excluded by DOCKERFILE_ARCH_EXCLUSIONS)"; \
+					continue; \
+				fi; \
+				if $(call registry_arch_is_excluded,$$arch); then \
+					echo "  Skipping $$arch for $$variant_name on $(DOCKER_REPO) (excluded by DOCKER_REGISTRY_ARCH_EXCLUSIONS)"; \
+					continue; \
+				fi; \
+				refs="$$refs $(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$$arch:$(SANITIZED_DOCKER_IMAGE_TAG)-$$variant_name"; \
+			done; \
+			if [ -z "$$refs" ]; then \
+				echo "Skipping manifest for $$variant_name variant (no supported architectures)"; \
+				continue; \
+			fi; \
+			DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create -a "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):$(SANITIZED_DOCKER_IMAGE_TAG)-$$variant_name" $$refs; \
 			DOCKER_CLI_EXPERIMENTAL=enabled docker manifest push "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):$(SANITIZED_DOCKER_IMAGE_TAG)-$$variant_name"; \
 		fi; \
 		if [ "$$dockerfile" = "Dockerfile" ]; then \
 			echo "Creating default variant ($$variant_name) manifest"; \
-			DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create -a "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):$(SANITIZED_DOCKER_IMAGE_TAG)" $(foreach ARCH,$(DOCKER_ARCHS),$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$(ARCH):$(SANITIZED_DOCKER_IMAGE_TAG)); \
+			refs=""; \
+			for arch in $(DOCKER_ARCHS); do \
+				if $(call dockerfile_arch_is_excluded,$$arch); then \
+					echo "  Skipping $$arch for default variant (excluded by DOCKERFILE_ARCH_EXCLUSIONS)"; \
+					continue; \
+				fi; \
+				if $(call registry_arch_is_excluded,$$arch); then \
+					echo "  Skipping $$arch for default variant on $(DOCKER_REPO) (excluded by DOCKER_REGISTRY_ARCH_EXCLUSIONS)"; \
+					continue; \
+				fi; \
+				refs="$$refs $(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$$arch:$(SANITIZED_DOCKER_IMAGE_TAG)"; \
+			done; \
+			if [ -z "$$refs" ]; then \
+				echo "Skipping default variant manifest (no supported architectures)"; \
+				continue; \
+			fi; \
+			DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create -a "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):$(SANITIZED_DOCKER_IMAGE_TAG)" $$refs; \
 			DOCKER_CLI_EXPERIMENTAL=enabled docker manifest push "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):$(SANITIZED_DOCKER_IMAGE_TAG)"; \
 		fi; \
 		if [ "$(DOCKER_IMAGE_TAG)" = "latest" ]; then \
 			if [ "$$dockerfile" != "Dockerfile" ] || [ "$$variant_name" != "default" ]; then \
 				echo "Creating manifest for $$variant_name variant version tag"; \
-				DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create -a "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):v$(DOCKER_MAJOR_VERSION_TAG)-$$variant_name" $(foreach ARCH,$(DOCKER_ARCHS),$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$(ARCH):v$(DOCKER_MAJOR_VERSION_TAG)-$$variant_name); \
+				refs=""; \
+				for arch in $(DOCKER_ARCHS); do \
+					if $(call dockerfile_arch_is_excluded,$$arch); then \
+						echo "  Skipping $$arch for $$variant_name version tag (excluded by DOCKERFILE_ARCH_EXCLUSIONS)"; \
+						continue; \
+					fi; \
+					if $(call registry_arch_is_excluded,$$arch); then \
+						echo "  Skipping $$arch for $$variant_name version tag on $(DOCKER_REPO) (excluded by DOCKER_REGISTRY_ARCH_EXCLUSIONS)"; \
+						continue; \
+					fi; \
+					refs="$$refs $(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$$arch:v$(DOCKER_MAJOR_VERSION_TAG)-$$variant_name"; \
+				done; \
+				if [ -z "$$refs" ]; then \
+					echo "Skipping version-tag manifest for $$variant_name variant (no supported architectures)"; \
+					continue; \
+				fi; \
+				DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create -a "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):v$(DOCKER_MAJOR_VERSION_TAG)-$$variant_name" $$refs; \
 				DOCKER_CLI_EXPERIMENTAL=enabled docker manifest push "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):v$(DOCKER_MAJOR_VERSION_TAG)-$$variant_name"; \
 			fi; \
 			if [ "$$dockerfile" = "Dockerfile" ]; then \
 				echo "Creating default variant version tag manifest"; \
-				DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create -a "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):v$(DOCKER_MAJOR_VERSION_TAG)" $(foreach ARCH,$(DOCKER_ARCHS),$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$(ARCH):v$(DOCKER_MAJOR_VERSION_TAG)); \
+				refs=""; \
+				for arch in $(DOCKER_ARCHS); do \
+					if $(call dockerfile_arch_is_excluded,$$arch); then \
+						echo "  Skipping $$arch for default variant version tag (excluded by DOCKERFILE_ARCH_EXCLUSIONS)"; \
+						continue; \
+					fi; \
+					if $(call registry_arch_is_excluded,$$arch); then \
+						echo "  Skipping $$arch for default variant version tag on $(DOCKER_REPO) (excluded by DOCKER_REGISTRY_ARCH_EXCLUSIONS)"; \
+						continue; \
+					fi; \
+					refs="$$refs $(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$$arch:v$(DOCKER_MAJOR_VERSION_TAG)"; \
+				done; \
+				if [ -z "$$refs" ]; then \
+					echo "Skipping default variant version-tag manifest (no supported architectures)"; \
+					continue; \
+				fi; \
+				DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create -a "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):v$(DOCKER_MAJOR_VERSION_TAG)" $$refs; \
 				DOCKER_CLI_EXPERIMENTAL=enabled docker manifest push "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):v$(DOCKER_MAJOR_VERSION_TAG)"; \
 			fi; \
 		fi; \

--- a/assets/go.mod
+++ b/assets/go.mod
@@ -1,6 +1,6 @@
 module github.com/prometheus/common/assets
 
-go 1.24.0
+go 1.25.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/prometheus/common
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/alecthomas/kingpin/v2 v2.4.0


### PR DESCRIPTION
* Update minimum Go version to 1.26.0.
* Update tests for Go 1.26.x.
* Migrate to GitHub Actions.
* Ignore package naming issues.
