### PR TITLE
config: guard against nil oauth2 credential in RoundTrip

### DIFF
--- a/config/http_config.go
+++ b/config/http_config.go
@@ -828,10 +828,7 @@ func (*refSecret) Immutable() bool {
 }
 
 // toSecret returns a SecretReader from one of the given sources, assuming exactly
-// one or none of the sources are provided. When no source is provided it
-// returns (nil, nil); callers MUST guard the returned reader with a nil check
-// before invoking any method on it — see the nil-deref issue tracked at
-// https://github.com/prometheus/common/issues/790.
+// one or none of the sources are provided.
 func toSecret(secretManager SecretManager, text Secret, file, ref string) (SecretReader, error) {
 	if text != "" {
 		return NewInlineSecret(string(text)), nil
@@ -1056,11 +1053,8 @@ func (rt *oauth2RoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 		needsInit bool
 	)
 
-	// oauthCredential can be nil when the caller constructed an oauth2
-	// config without any client-secret source (Secret/File/Ref all empty).
-	// That is an invalid config — oauth2 requires a client secret — but
-	// rather than panicking on the Immutable()/Fetch() calls below, surface
-	// it as a request-time error so the caller can see it.
+	// This should not happen when config goes through the normal Prometheus
+	// validation path, but guard against a nil credential to avoid a panic.
 	if rt.oauthCredential == nil {
 		return nil, errors.New("oauth2 client secret is required")
 	}

--- a/config/http_config.go
+++ b/config/http_config.go
@@ -828,7 +828,10 @@ func (*refSecret) Immutable() bool {
 }
 
 // toSecret returns a SecretReader from one of the given sources, assuming exactly
-// one or none of the sources are provided.
+// one or none of the sources are provided. When no source is provided it
+// returns (nil, nil); callers MUST guard the returned reader with a nil check
+// before invoking any method on it — see the nil-deref issue tracked at
+// https://github.com/prometheus/common/issues/790.
 func toSecret(secretManager SecretManager, text Secret, file, ref string) (SecretReader, error) {
 	if text != "" {
 		return NewInlineSecret(string(text)), nil
@@ -1052,6 +1055,15 @@ func (rt *oauth2RoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 		secret    string
 		needsInit bool
 	)
+
+	// oauthCredential can be nil when the caller constructed an oauth2
+	// config without any client-secret source (Secret/File/Ref all empty).
+	// That is an invalid config — oauth2 requires a client secret — but
+	// rather than panicking on the Immutable()/Fetch() calls below, surface
+	// it as a request-time error so the caller can see it.
+	if rt.oauthCredential == nil {
+		return nil, errors.New("oauth2 client secret is required")
+	}
 
 	rt.mtx.RLock()
 	secret = rt.lastSecret


### PR DESCRIPTION
## Summary

`toSecret` returns `(nil, nil)` when no credential source is configured. Most callers guarded the returned `SecretReader` with `!= nil` before invoking `Fetch`, but `oauth2RoundTripper.RoundTrip` reached directly into `rt.oauthCredential.Immutable()` and would nil-deref panic when someone supplied an `oauth2` block with no client-secret source (likely the proximate cause referenced by prometheus/prometheus#16622).

This PR:

1. Adds an explicit nil-guard in `oauth2RoundTripper.RoundTrip` that returns `errors.New("oauth2 client secret is required")` instead of panicking.
2. Documents `toSecret`'s nil-return contract so future callers explicitly acknowledge it.

Fixes #790

## Test plan

- [x] `go build ./...`
- [x] `go test ./config/`
- [x] `gofmt` clean

Signed-off-by: Ali <alliasgher123@gmail.com>