### PR TITLE
config: change NewOAuth2RoundTripper to accept variadic HTTPClientOption

### DIFF
--- a/config/http_config.go
+++ b/config/http_config.go
@@ -717,7 +717,7 @@ func NewRoundTripperFromConfigWithContext(ctx context.Context, cfg HTTPClientCon
 					return nil, fmt.Errorf("unable to use client secret: %w", err)
 				}
 			}
-			rt = NewOAuth2RoundTripper(oauthCredential, cfg.OAuth2, rt, &opts)
+			rt = NewOAuth2RoundTripper(oauthCredential, cfg.OAuth2, rt, optFuncs...)
 		}
 
 		if cfg.HTTPHeaders != nil {
@@ -942,16 +942,26 @@ type oauth2RoundTripper struct {
 	client          *http.Client
 }
 
-func NewOAuth2RoundTripper(oauthCredential SecretReader, config *OAuth2, next http.RoundTripper, opts *httpClientOptions) http.RoundTripper {
+// NewOAuth2RoundTripper returns a round tripper that performs OAuth2
+// authentication. The opts variadic parameter accepts any HTTPClientOption
+// (e.g. WithDialContextFunc, WithKeepAlivesDisabled) so that callers outside
+// this package can fully configure the transport without needing access to the
+// unexported *httpClientOptions type.
+func NewOAuth2RoundTripper(oauthCredential SecretReader, config *OAuth2, next http.RoundTripper, optFuncs ...HTTPClientOption) http.RoundTripper {
 	if oauthCredential == nil {
 		oauthCredential = NewInlineSecret("")
+	}
+
+	opts := defaultHTTPClientOptions
+	for _, opt := range optFuncs {
+		opt.applyToHTTPClientOptions(&opts)
 	}
 
 	return &oauth2RoundTripper{
 		config: config,
 		// A correct tokenSource will be added later on.
 		lastRT:          &oauth2.Transport{Base: next},
-		opts:            opts,
+		opts:            &opts,
 		oauthCredential: oauthCredential,
 	}
 }

--- a/config/http_config_test.go
+++ b/config/http_config_test.go
@@ -1519,7 +1519,7 @@ endpoint_params:
 	require.Truef(t, reflect.DeepEqual(unmarshalledConfig, expectedConfig), "Got unmarshalled config %v, expected %v", unmarshalledConfig, expectedConfig)
 
 	secret := NewInlineSecret(string(expectedConfig.ClientSecret))
-	rt := NewOAuth2RoundTripper(secret, &expectedConfig, http.DefaultTransport, &defaultHTTPClientOptions)
+	rt := NewOAuth2RoundTripper(secret, &expectedConfig, http.DefaultTransport)
 
 	client := http.Client{
 		Transport: rt,
@@ -1654,7 +1654,7 @@ endpoint_params:
 	require.Truef(t, reflect.DeepEqual(unmarshalledConfig, expectedConfig), "Got unmarshalled config %v, expected %v", unmarshalledConfig, expectedConfig)
 
 	secret := NewFileSecret(expectedConfig.ClientSecretFile)
-	rt := NewOAuth2RoundTripper(secret, &expectedConfig, http.DefaultTransport, &defaultHTTPClientOptions)
+	rt := NewOAuth2RoundTripper(secret, &expectedConfig, http.DefaultTransport)
 
 	client := http.Client{
 		Transport: rt,
@@ -1768,7 +1768,7 @@ endpoint_params:
 	require.Truef(t, reflect.DeepEqual(unmarshalledConfig, expectedConfig), "Got unmarshalled config %v, expected %v", unmarshalledConfig, expectedConfig)
 
 	clientCertificateKey := NewFileSecret(expectedConfig.ClientCertificateKeyFile)
-	rt := NewOAuth2RoundTripper(clientCertificateKey, &expectedConfig, http.DefaultTransport, &defaultHTTPClientOptions)
+	rt := NewOAuth2RoundTripper(clientCertificateKey, &expectedConfig, http.DefaultTransport)
 
 	client := http.Client{
 		Transport: rt,


### PR DESCRIPTION
## Summary

`NewOAuth2RoundTripper` previously accepted `*httpClientOptions` as its fourth
parameter — an **unexported** type. This made the function effectively
uncallable with a non-nil options argument from any package outside
`prometheus/common/config`, forcing downstream users (e.g. Grafana Alloy) to
resort to reflection or `unsafe` pointer tricks.

Reported upstream in prometheus/prometheus#18329.

## Change

Replace the unexported `*httpClientOptions` parameter with variadic
`...HTTPClientOption` — the **exported** interface already used by
`NewRoundTripperFromConfigWithContext`:

```go
// Before (unusable externally with non-nil opts):
func NewOAuth2RoundTripper(cred SecretReader, cfg *OAuth2, next http.RoundTripper, opts *httpClientOptions) http.RoundTripper

// After (fully usable from any package):
func NewOAuth2RoundTripper(cred SecretReader, cfg *OAuth2, next http.RoundTripper, optFuncs ...HTTPClientOption) http.RoundTripper
```

Internally the function builds its own `httpClientOptions` copy from the supplied options starting from `defaultHTTPClientOptions`, so behaviour is identical to before when no options are passed.

## Call sites updated

- Internal call in `NewRoundTripperFromConfigWithContext`: passes `optFuncs...` instead of `&opts`
- Three test call sites that passed `&defaultHTTPClientOptions` now pass no options (equivalent — defaults are unchanged)

## Tests

```
go test ./config/...   # all pass
```