### PR TITLE
config: add client_assertion / client_assertion_file OAuth2 fields (RFC 7521/7523)

### DIFF
--- a/config/http_config.go
+++ b/config/http_config.go
@@ -278,12 +278,12 @@ type OAuth2 struct {
 	// ClientAssertionFile is a path to a file whose contents are used as the
 	// client_assertion. The file is re-read on every token refresh so that
 	// rotated assertions are picked up automatically.
-	ClientAssertionFile string  `yaml:"client_assertion_file,omitempty" json:"client_assertion_file,omitempty"`
-	Scopes              []string `yaml:"scopes,omitempty" json:"scopes,omitempty"`
-	TokenURL       string                 `yaml:"token_url,omitempty" json:"token_url,omitempty"`
-	EndpointParams map[string]string      `yaml:"endpoint_params,omitempty" json:"endpoint_params,omitempty"`
-	TLSConfig      TLSConfig              `yaml:"tls_config,omitempty"`
-	ProxyConfig    `yaml:",inline"`
+	ClientAssertionFile string            `yaml:"client_assertion_file,omitempty" json:"client_assertion_file,omitempty"`
+	Scopes              []string          `yaml:"scopes,omitempty" json:"scopes,omitempty"`
+	TokenURL            string            `yaml:"token_url,omitempty" json:"token_url,omitempty"`
+	EndpointParams      map[string]string `yaml:"endpoint_params,omitempty" json:"endpoint_params,omitempty"`
+	TLSConfig           TLSConfig         `yaml:"tls_config,omitempty"`
+	ProxyConfig         `yaml:",inline"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
@@ -725,18 +725,19 @@ func NewRoundTripperFromConfigWithContext(ctx context.Context, cfg HTTPClientCon
 				err             error
 			)
 
-			if cfg.OAuth2.GrantType == grantTypeJWTBearer {
+			switch {
+			case cfg.OAuth2.GrantType == grantTypeJWTBearer:
 				oauthCredential, err = toSecret(opts.secretManager, cfg.OAuth2.ClientCertificateKey, cfg.OAuth2.ClientCertificateKeyFile, cfg.OAuth2.ClientCertificateKeyRef)
 				if err != nil {
 					return nil, fmt.Errorf("unable to use client certificate: %w", err)
 				}
-			} else if len(cfg.OAuth2.ClientAssertion) > 0 || len(cfg.OAuth2.ClientAssertionFile) > 0 {
+			case len(cfg.OAuth2.ClientAssertion) > 0 || len(cfg.OAuth2.ClientAssertionFile) > 0:
 				// Pre-signed JWT assertion (RFC 7521 §4.2 / RFC 7523 §2.2).
 				oauthCredential, err = toSecret(nil, cfg.OAuth2.ClientAssertion, cfg.OAuth2.ClientAssertionFile, "")
 				if err != nil {
 					return nil, fmt.Errorf("unable to use client assertion: %w", err)
 				}
-			} else {
+			default:
 				oauthCredential, err = toSecret(opts.secretManager, cfg.OAuth2.ClientSecret, cfg.OAuth2.ClientSecretFile, cfg.OAuth2.ClientSecretRef)
 				if err != nil {
 					return nil, fmt.Errorf("unable to use client secret: %w", err)
@@ -1025,7 +1026,8 @@ func (rt *oauth2RoundTripper) newOauth2TokenSource(req *http.Request, clientCred
 
 	var config oauth2TokenSourceConfig
 
-	if rt.config.GrantType == grantTypeJWTBearer {
+	switch {
+	case rt.config.GrantType == grantTypeJWTBearer:
 		// RFC 7523 3.1 - JWT authorization grants
 		// RFC 7523 3.2 - Client Authentication Processing is not implement upstream yet,
 		// see https://github.com/golang/oauth2/pull/745
@@ -1058,7 +1060,7 @@ func (rt *oauth2RoundTripper) newOauth2TokenSource(req *http.Request, clientCred
 			PrivateClaims:    rt.config.Claims,
 			EndpointParams:   mapToValues(rt.config.EndpointParams),
 		}
-	} else if len(rt.config.ClientAssertion) > 0 || len(rt.config.ClientAssertionFile) > 0 {
+	case len(rt.config.ClientAssertion) > 0 || len(rt.config.ClientAssertionFile) > 0:
 		// RFC 7521 §4.2 / RFC 7523 §2.2 — client_assertion authentication.
 		// The pre-signed JWT is sent as client_assertion together with the
 		// appropriate client_assertion_type; no client_secret is included.
@@ -1071,7 +1073,7 @@ func (rt *oauth2RoundTripper) newOauth2TokenSource(req *http.Request, clientCred
 			TokenURL:       rt.config.TokenURL,
 			EndpointParams: params,
 		}
-	} else {
+	default:
 		config = &clientcredentials.Config{
 			ClientID:       rt.config.ClientID,
 			ClientSecret:   clientCredential,

--- a/config/http_config.go
+++ b/config/http_config.go
@@ -269,8 +269,17 @@ type OAuth2 struct {
 	Audience string `yaml:"audience,omitempty" json:"audience,omitempty"`
 	// Claims is a map of claims to be added to the JWT token. Only used if
 	// GrantType is set to "urn:ietf:params:oauth:grant-type:jwt-bearer".
-	Claims         map[string]interface{} `yaml:"claims,omitempty" json:"claims,omitempty"`
-	Scopes         []string               `yaml:"scopes,omitempty" json:"scopes,omitempty"`
+	Claims map[string]interface{} `yaml:"claims,omitempty" json:"claims,omitempty"`
+	// ClientAssertion is a pre-signed JWT sent as the client_assertion parameter
+	// (RFC 7521 §4.2 / RFC 7523 §2.2). Use this when the assertion is generated
+	// externally (e.g. by a sidecar, KMS, or separate job). Mutually exclusive
+	// with client_secret* and client_certificate_key*.
+	ClientAssertion Secret `yaml:"client_assertion,omitempty" json:"client_assertion,omitempty"`
+	// ClientAssertionFile is a path to a file whose contents are used as the
+	// client_assertion. The file is re-read on every token refresh so that
+	// rotated assertions are picked up automatically.
+	ClientAssertionFile string  `yaml:"client_assertion_file,omitempty" json:"client_assertion_file,omitempty"`
+	Scopes              []string `yaml:"scopes,omitempty" json:"scopes,omitempty"`
 	TokenURL       string                 `yaml:"token_url,omitempty" json:"token_url,omitempty"`
 	EndpointParams map[string]string      `yaml:"endpoint_params,omitempty" json:"endpoint_params,omitempty"`
 	TLSConfig      TLSConfig              `yaml:"tls_config,omitempty"`
@@ -449,6 +458,16 @@ func (c *HTTPClientConfig) Validate() error {
 			}
 		} else if nonZeroCount(len(c.OAuth2.ClientSecret) > 0, len(c.OAuth2.ClientSecretFile) > 0, len(c.OAuth2.ClientSecretRef) > 0) > 1 {
 			return errors.New("at most one of oauth2 client_secret, client_secret_file & client_secret_ref must be configured using grant-type=client_credentials")
+		}
+		if hasAssertion := nonZeroCount(len(c.OAuth2.ClientAssertion) > 0, len(c.OAuth2.ClientAssertionFile) > 0) > 0; hasAssertion {
+			if nonZeroCount(len(c.OAuth2.ClientAssertion) > 0, len(c.OAuth2.ClientAssertionFile) > 0) > 1 {
+				return errors.New("at most one of oauth2 client_assertion and client_assertion_file must be configured")
+			}
+			hasSecret := nonZeroCount(len(c.OAuth2.ClientSecret) > 0, len(c.OAuth2.ClientSecretFile) > 0, len(c.OAuth2.ClientSecretRef) > 0) > 0
+			hasCertKey := nonZeroCount(len(c.OAuth2.ClientCertificateKey) > 0, len(c.OAuth2.ClientCertificateKeyFile) > 0, len(c.OAuth2.ClientCertificateKeyRef) > 0) > 0
+			if hasSecret || hasCertKey {
+				return errors.New("oauth2 client_assertion cannot be combined with client_secret or client_certificate_key")
+			}
 		}
 	}
 	if err := c.ProxyConfig.Validate(); err != nil {
@@ -710,6 +729,12 @@ func NewRoundTripperFromConfigWithContext(ctx context.Context, cfg HTTPClientCon
 				oauthCredential, err = toSecret(opts.secretManager, cfg.OAuth2.ClientCertificateKey, cfg.OAuth2.ClientCertificateKeyFile, cfg.OAuth2.ClientCertificateKeyRef)
 				if err != nil {
 					return nil, fmt.Errorf("unable to use client certificate: %w", err)
+				}
+			} else if len(cfg.OAuth2.ClientAssertion) > 0 || len(cfg.OAuth2.ClientAssertionFile) > 0 {
+				// Pre-signed JWT assertion (RFC 7521 §4.2 / RFC 7523 §2.2).
+				oauthCredential, err = toSecret(nil, cfg.OAuth2.ClientAssertion, cfg.OAuth2.ClientAssertionFile, "")
+				if err != nil {
+					return nil, fmt.Errorf("unable to use client assertion: %w", err)
 				}
 			} else {
 				oauthCredential, err = toSecret(opts.secretManager, cfg.OAuth2.ClientSecret, cfg.OAuth2.ClientSecretFile, cfg.OAuth2.ClientSecretRef)
@@ -1032,6 +1057,19 @@ func (rt *oauth2RoundTripper) newOauth2TokenSource(req *http.Request, clientCred
 			Audience:         rt.config.Audience,
 			PrivateClaims:    rt.config.Claims,
 			EndpointParams:   mapToValues(rt.config.EndpointParams),
+		}
+	} else if len(rt.config.ClientAssertion) > 0 || len(rt.config.ClientAssertionFile) > 0 {
+		// RFC 7521 §4.2 / RFC 7523 §2.2 — client_assertion authentication.
+		// The pre-signed JWT is sent as client_assertion together with the
+		// appropriate client_assertion_type; no client_secret is included.
+		params := mapToValues(rt.config.EndpointParams)
+		params.Set("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer")
+		params.Set("client_assertion", clientCredential)
+		config = &clientcredentials.Config{
+			ClientID:       rt.config.ClientID,
+			Scopes:         rt.config.Scopes,
+			TokenURL:       rt.config.TokenURL,
+			EndpointParams: params,
 		}
 	} else {
 		config = &clientcredentials.Config{

--- a/config/http_config_test.go
+++ b/config/http_config_test.go
@@ -2321,3 +2321,81 @@ func TestMultipleHeaders(t *testing.T) {
 	_, err = client.Get(ts.URL)
 	require.NoErrorf(t, err, "can't fetch URL: %v", err)
 }
+
+func TestOAuth2WithClientAssertion(t *testing.T) {
+	const preSignedJWT = "header.payload.signature"
+
+	var (
+		gotAssertionType string
+		gotAssertion     string
+	)
+	tokenTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		gotAssertionType = r.FormValue("client_assertion_type")
+		gotAssertion = r.FormValue("client_assertion")
+		res, _ := json.Marshal(oauth2TestServerResponse{AccessToken: "tok", TokenType: "Bearer"})
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(res)
+	}))
+	defer tokenTS.Close()
+	appTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "Bearer tok", r.Header.Get("Authorization"))
+		fmt.Fprintln(w, "ok")
+	}))
+	defer appTS.Close()
+
+	cfg := &HTTPClientConfig{
+		OAuth2: &OAuth2{
+			ClientID:        "my-client",
+			ClientAssertion: Secret(preSignedJWT),
+			TokenURL:        tokenTS.URL,
+		},
+	}
+	client, err := NewClientFromConfig(*cfg, "test")
+	require.NoError(t, err)
+
+	_, err = client.Get(appTS.URL)
+	require.NoError(t, err)
+
+	require.Equal(t, "urn:ietf:params:oauth:client-assertion-type:jwt-bearer", gotAssertionType)
+	require.Equal(t, preSignedJWT, gotAssertion)
+}
+
+func TestOAuth2ClientAssertionValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     OAuth2
+		wantErr string
+	}{
+		{
+			name:    "both client_assertion and client_assertion_file",
+			cfg:     OAuth2{ClientID: "x", TokenURL: "http://t", ClientAssertion: "jwt", ClientAssertionFile: "/f"},
+			wantErr: "at most one of oauth2 client_assertion and client_assertion_file must be configured",
+		},
+		{
+			name:    "client_assertion with client_secret",
+			cfg:     OAuth2{ClientID: "x", TokenURL: "http://t", ClientAssertion: "jwt", ClientSecret: "s"},
+			wantErr: "oauth2 client_assertion cannot be combined with client_secret or client_certificate_key",
+		},
+		{
+			name:    "client_assertion with client_certificate_key",
+			cfg:     OAuth2{ClientID: "x", TokenURL: "http://t", ClientAssertion: "jwt", ClientCertificateKey: "k"},
+			wantErr: "oauth2 client_assertion cannot be combined with client_secret or client_certificate_key",
+		},
+		{
+			name: "client_assertion_file alone is valid",
+			cfg:  OAuth2{ClientID: "x", TokenURL: "http://t", ClientAssertionFile: "/path/to/jwt"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := tc.cfg
+			err := (&HTTPClientConfig{OAuth2: &cfg}).Validate()
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Some environments generate client assertions externally — via a KMS, sidecar, or dedicated job — and inject the pre-signed JWT as a file or environment variable. The existing `client_certificate_key*` fields require the library to sign the JWT itself, which is impossible in these cases.

Requested in #869.

## New fields

```yaml
oauth2:
  client_id: my-client
  token_url: https://token.example.com/token
  # Option A – inline pre-signed JWT
  client_assertion: "<base64url-header>.<base64url-payload>.<signature>"
  # Option B – file path (re-read on every token refresh, supports rotation)
  # client_assertion_file: /var/run/secrets/assertion.jwt
```

When either field is present the transport:
1. Reads the assertion through the standard `SecretReader` path (inline or file, with live rotation for the file case)
2. POSTs to the token endpoint with:
   - `client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer`
   - `client_assertion=<jwt>`
   - No `client_secret` (the assertion is the credential)

## Validation

- `client_assertion` and `client_assertion_file` are mutually exclusive
- Cannot be combined with `client_secret*` or `client_certificate_key*`

## Tests

- `TestOAuth2WithClientAssertion` — end-to-end test with a local token server verifying the assertion params
- `TestOAuth2ClientAssertionValidation` — four validation cases (dual-field, mixed-with-secret, mixed-with-cert-key, file-alone valid)

Closes #869