### PR TITLE
expfmt: tolerate trailing whitespace after samples

### DIFF
--- a/expfmt/text_parse.go
+++ b/expfmt/text_parse.go
@@ -602,15 +602,21 @@ func (p *TextParser) readingValue() stateFn {
 	if p.currentByte == '\n' {
 		return p.startOfLine
 	}
-	return p.startTimestamp
+	if isBlankOrTab(p.currentByte) {
+		p.skipBlankTabIfCurrentBlankTab()
+		if p.err != nil {
+			return nil // Unexpected end of input.
+		}
+		if p.currentByte == '\n' {
+			return p.startOfLine
+		}
+	}
+	return p.readingTimestamp
 }
 
-// startTimestamp represents the state where the next byte read from p.buf is
-// the start of the timestamp (or whitespace leading up to it).
-func (p *TextParser) startTimestamp() stateFn {
-	if p.skipBlankTab(); p.err != nil {
-		return nil // Unexpected end of input.
-	}
+// readingTimestamp represents the state where the last byte read (now in
+// p.currentByte) is the first byte of the timestamp.
+func (p *TextParser) readingTimestamp() stateFn {
 	if p.readTokenUntilWhitespace(); p.err != nil {
 		return nil // Unexpected end of input.
 	}
@@ -621,6 +627,18 @@ func (p *TextParser) startTimestamp() stateFn {
 		return nil
 	}
 	p.currentMetric.TimestampMs = proto.Int64(timestamp)
+	if p.currentByte == '\n' {
+		return p.startOfLine
+	}
+	if isBlankOrTab(p.currentByte) {
+		p.skipBlankTabIfCurrentBlankTab()
+		if p.err != nil {
+			return nil // Unexpected end of input.
+		}
+		if p.currentByte == '\n' {
+			return p.startOfLine
+		}
+	}
 	if p.readTokenUntilNewline(false); p.err != nil {
 		return nil // Unexpected end of input.
 	}

--- a/expfmt/text_parse_test.go
+++ b/expfmt/text_parse_test.go
@@ -957,6 +957,35 @@ request_duration_microseconds_count 2693
 				},
 			},
 		},
+		// 18: Trailing blanks and tabs after sample values and timestamps.
+		{
+			in: "trailing_value_space 1 \t \ntrailing_timestamp_space 2 123 \t \n",
+			out: []*dto.MetricFamily{
+				{
+					Name: proto.String("trailing_value_space"),
+					Type: dto.MetricType_UNTYPED.Enum(),
+					Metric: []*dto.Metric{
+						{
+							Untyped: &dto.Untyped{
+								Value: proto.Float64(1),
+							},
+						},
+					},
+				},
+				{
+					Name: proto.String("trailing_timestamp_space"),
+					Type: dto.MetricType_UNTYPED.Enum(),
+					Metric: []*dto.Metric{
+						{
+							Untyped: &dto.Untyped{
+								Value: proto.Float64(2),
+							},
+							TimestampMs: proto.Int64(123),
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for i, scenario := range scenarios {


### PR DESCRIPTION
Fixes #33.

The text parser treated blanks after a sample value as the start of a timestamp, and blanks after a timestamp as a spurious string. This skips trailing blanks/tabs before checking for the line ending, while keeping timestamp parsing and invalid trailing text behavior unchanged.

Tests:
- `go test ./expfmt -run TestTextParse -count=1`
- `go test ./expfmt -count=1`
- `go test ./... -count=1` fails locally on Windows in `config.TestMissingBearerAuthFile` because the test expects the Unix `no such file or directory` wording.