### PR TITLE
model: reduce allocations in Time.UnmarshalJSON

### DIFF
--- a/model/time.go
+++ b/model/time.go
@@ -140,13 +140,16 @@ func (t *Time) UnmarshalJSON(b []byte) error {
 		prec := dotPrecision - len(frac)
 		if prec < 0 {
 			frac = frac[:dotPrecision]
-		} else if prec > 0 {
-			frac += strings.Repeat("0", prec)
 		}
-
 		va, err := strconv.ParseInt(frac, 10, 32)
 		if err != nil {
 			return err
+		}
+		switch prec {
+		case 1:
+			va *= 10
+		case 2:
+			va *= 100
 		}
 
 		// If the value was something like -0.1 the negative is lost in the

--- a/model/time.go
+++ b/model/time.go
@@ -123,44 +123,39 @@ func (t Time) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements the json.Unmarshaler interface.
 func (t *Time) UnmarshalJSON(b []byte) error {
-	p := strings.Split(string(b), ".")
-	switch len(p) {
-	case 1:
-		v, err := strconv.ParseInt(p[0], 10, 64)
+	base, frac, found := strings.Cut(string(b), ".")
+	if !found {
+		v, err := strconv.ParseInt(base, 10, 64)
 		if err != nil {
 			return err
 		}
 		*t = Time(v * second)
-
-	case 2:
-		v, err := strconv.ParseInt(p[0], 10, 64)
+	} else {
+		v, err := strconv.ParseInt(base, 10, 64)
 		if err != nil {
 			return err
 		}
 		v *= second
 
-		prec := dotPrecision - len(p[1])
+		prec := dotPrecision - len(frac)
 		if prec < 0 {
-			p[1] = p[1][:dotPrecision]
+			frac = frac[:dotPrecision]
 		} else if prec > 0 {
-			p[1] += strings.Repeat("0", prec)
+			frac += strings.Repeat("0", prec)
 		}
 
-		va, err := strconv.ParseInt(p[1], 10, 32)
+		va, err := strconv.ParseInt(frac, 10, 32)
 		if err != nil {
 			return err
 		}
 
 		// If the value was something like -0.1 the negative is lost in the
 		// parsing because of the leading zero, this ensures that we capture it.
-		if len(p[0]) > 0 && p[0][0] == '-' && v+va > 0 {
+		if len(base) > 0 && base[0] == '-' && v+va > 0 {
 			*t = Time(v+va) * -1
 		} else {
 			*t = Time(v + va)
 		}
-
-	default:
-		return fmt.Errorf("invalid time %q", string(b))
 	}
 	return nil
 }

--- a/model/time.go
+++ b/model/time.go
@@ -135,7 +135,6 @@ func (t *Time) UnmarshalJSON(b []byte) error {
 		if err != nil {
 			return err
 		}
-		v *= second
 
 		prec := dotPrecision - len(frac)
 		if prec < 0 {
@@ -152,13 +151,10 @@ func (t *Time) UnmarshalJSON(b []byte) error {
 			va *= 100
 		}
 
-		// If the value was something like -0.1 the negative is lost in the
-		// parsing because of the leading zero, this ensures that we capture it.
-		if len(base) > 0 && base[0] == '-' && v+va > 0 {
-			*t = Time(v+va) * -1
-		} else {
-			*t = Time(v + va)
+		if len(base) > 0 && base[0] == '-' {
+			va = -va
 		}
+		*t = Time(v*second + va)
 	}
 	return nil
 }

--- a/model/time_test.go
+++ b/model/time_test.go
@@ -460,3 +460,17 @@ func BenchmarkParseDuration(b *testing.B) {
 		require.NoError(b, err)
 	}
 }
+
+func BenchmarkUnmarshalTime(b *testing.B) {
+	cases := []string{"1780924784", "1780924784.01", "1780924784.001"}
+
+	for _, c := range cases {
+		b.Run(c, func(b *testing.B) {
+			var t Time
+			data := []byte(c)
+			for b.Loop() {
+				_ = t.UnmarshalJSON(data)
+			}
+		})
+	}
+}

--- a/model/time_test.go
+++ b/model/time_test.go
@@ -432,6 +432,11 @@ func TestTimeJSON(t *testing.T) {
 	}{
 		{Time(1), `0.001`},
 		{Time(-1), `-0.001`},
+		{Time(1001), `1.001`},
+		{Time(-1001), `-1.001`},
+		{Time(123000), `123`},
+		{Time(123100), `123.1`},
+		{Time(123010), `123.01`},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
The basic idea was to use `strings.Cut` instead of `strings.Split`.

However I also removed another allocation if the decimal was smaller than three figures, and fixed a bug for negative times.

Benchmarks:
```
goos: linux
goarch: amd64
pkg: github.com/prometheus/common/model
cpu: Intel(R) Core(TM) i7-14700K
                                │   before    │               after                │
                                │   sec/op    │   sec/op     vs base               │
UnmarshalTime/1780924784-28       39.89n ± 0%   18.98n ± 1%  -52.42% (p=0.002 n=6)
UnmarshalTime/1780924784.01-28    67.99n ± 0%   26.68n ± 1%  -60.76% (p=0.002 n=6)
UnmarshalTime/1780924784.001-28   53.84n ± 1%   27.64n ± 0%  -48.66% (p=0.002 n=6)
geomean                           52.66n        24.10n       -54.23%

                                │   before   │                 after                 │
                                │    B/op    │   B/op     vs base                    │
UnmarshalTime/1780924784-28       32.00 ± 0%   0.00 ± 0%  -100.00% (p=0.002 n=6)
UnmarshalTime/1780924784.01-28    48.00 ± 0%   0.00 ± 0%  -100.00% (p=0.002 n=6)
UnmarshalTime/1780924784.001-28   48.00 ± 0%   0.00 ± 0%  -100.00% (p=0.002 n=6)
geomean                           41.93                   ?                      ¹ ²
¹ summaries must be >0 to compute geomean
² ratios must be >0 to compute geomean

                                │   before   │                 after                  │
                                │ allocs/op  │ allocs/op   vs base                    │
UnmarshalTime/1780924784-28       2.000 ± 0%   0.000 ± 0%  -100.00% (p=0.002 n=6)
UnmarshalTime/1780924784.01-28    3.000 ± 0%   0.000 ± 0%  -100.00% (p=0.002 n=6)
UnmarshalTime/1780924784.001-28   2.000 ± 0%   0.000 ± 0%  -100.00% (p=0.002 n=6)
geomean                           2.289                    ?                      ¹ ²
¹ summaries must be >0 to compute geomean
² ratios must be >0 to compute geomean
```