### PR TITLE
config: check cross-host redirect before OAuth2 token fetch

### DIFF
--- a/config/http_config.go
+++ b/config/http_config.go
@@ -1067,6 +1067,18 @@ func (rt *oauth2RoundTripper) newOauth2TokenSource(req *http.Request, clientCred
 }
 
 func (rt *oauth2RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if isCrossHostRedirect(req) {
+		// Bypass the OAuth2 transport so no token is attached. Read Base under
+		// the lock to avoid a data race with concurrent reconfigurations.
+		rt.mtx.RLock()
+		base := rt.lastRT.Base
+		rt.mtx.RUnlock()
+		if base == nil {
+			base = http.DefaultTransport
+		}
+		return base.RoundTrip(req)
+	}
+
 	var (
 		secret    string
 		needsInit bool
@@ -1110,9 +1122,6 @@ func (rt *oauth2RoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 	rt.mtx.RLock()
 	currentRT := rt.lastRT
 	rt.mtx.RUnlock()
-	if isCrossHostRedirect(req) {
-		return currentRT.Base.RoundTrip(req)
-	}
 	return currentRT.RoundTrip(req)
 }
 


### PR DESCRIPTION
Move isCrossHostRedirect early in oauth2RoundTripper.RoundTrip so that cross-host redirects bypass token-source initialisation entirely and go straight to Base.RoundTrip. Base is read under the RLock to avoid a data race with concurrent reconfigurations.