### PR TITLE
config: resolve LoadHTTPConfigFile paths relative to the config file

### DIFF
--- a/config/http_config.go
+++ b/config/http_config.go
@@ -325,7 +325,7 @@ func LoadHTTPConfigFile(filename string) (*HTTPClientConfig, []byte, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	cfg.SetDirectory(filepath.Dir(filepath.Dir(filename)))
+	cfg.SetDirectory(filepath.Dir(filename))
 	return cfg, content, nil
 }
 

--- a/config/http_config_test.go
+++ b/config/http_config_test.go
@@ -2720,3 +2720,32 @@ func TestMultipleHeaders(t *testing.T) {
 	_, err = client.Get(ts.URL)
 	require.NoErrorf(t, err, "can't fetch URL: %v", err)
 }
+
+// TestLoadHTTPConfigFileResolvesPathsRelativeToConfigFile ensures that relative
+// file paths inside a config loaded with LoadHTTPConfigFile are resolved
+// relative to the directory containing the config file, as documented by the
+// SetDirectory contract.
+func TestLoadHTTPConfigFileResolvesPathsRelativeToConfigFile(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "header-value", r.Header.Get("X-Test"))
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(ts.Close)
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "header-value"), []byte("header-value\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "http.yml"), []byte(`http_headers:
+  X-Test:
+    files: [header-value]
+`), 0o644))
+
+	cfg, _, err := LoadHTTPConfigFile(filepath.Join(dir, "http.yml"))
+	require.NoErrorf(t, err, "Error loading HTTP client config: %v", err)
+	require.Equal(t, filepath.Join(dir, "header-value"), cfg.HTTPHeaders.Headers["X-Test"].Files[0])
+
+	client, err := NewClientFromConfig(*cfg, "test")
+	require.NoErrorf(t, err, "Error creating HTTP Client: %v", err)
+
+	_, err = client.Get(ts.URL)
+	require.NoErrorf(t, err, "can't fetch URL: %v", err)
+}

--- a/config/testdata/http.conf.basic-auth.bad-username.yaml
+++ b/config/testdata/http.conf.basic-auth.bad-username.yaml
@@ -1,4 +1,4 @@
 basic_auth:
   username: user
-  username_file: testdata/basic-auth-username
+  username_file: basic-auth-username
   password: foo

--- a/config/testdata/http.conf.basic-auth.good.yaml
+++ b/config/testdata/http.conf.basic-auth.good.yaml
@@ -1,3 +1,3 @@
 basic_auth:
   username: user
-  password_file: testdata/basic-auth-password
+  password_file: basic-auth-password

--- a/config/testdata/http.conf.basic-auth.too-much.bad.yaml
+++ b/config/testdata/http.conf.basic-auth.too-much.bad.yaml
@@ -1,4 +1,4 @@
 basic_auth:
   username: user
   password: foo
-  password_file: testdata/basic-auth-password
+  password_file: basic-auth-password

--- a/config/testdata/http.conf.basic-auth.username-file.good.yaml
+++ b/config/testdata/http.conf.basic-auth.username-file.good.yaml
@@ -1,3 +1,3 @@
 basic_auth:
-  username_file: testdata/basic-auth-username
-  password_file: testdata/basic-auth-password
+  username_file: basic-auth-username
+  password_file: basic-auth-password

--- a/config/testdata/http.conf.headers-multiple.good.yaml
+++ b/config/testdata/http.conf.headers-multiple.good.yaml
@@ -5,4 +5,4 @@ http_headers:
     values: [value2a]
     secrets: [value2b, value2c]
   three:
-    files: [testdata/headers-file-a, testdata/headers-file-b, testdata/headers-file-c]
+    files: [headers-file-a, headers-file-b, headers-file-c]

--- a/config/testdata/http.conf.headers.good.yaml
+++ b/config/testdata/http.conf.headers.good.yaml
@@ -4,4 +4,4 @@ http_headers:
   two:
     secrets: [value2]
   three:
-    files: [testdata/headers-file]
+    files: [headers-file]


### PR DESCRIPTION
LoadHTTPConfigFile called SetDirectory with filepath.Dir(filepath.Dir(filename)), resolving relative file paths (http_headers files, *_file credentials) against the config file's grandparent directory instead of its own directory. This contradicts the SetDirectory contract and every other config loader.

The behavior was masked by the testdata fixtures, which prefixed file paths with the config file's own directory name (e.g. files: [testdata/headers-file] for a config living in testdata/) to compensate. Drop those redundant prefixes and add a regression test that loads a config from a temp dir and asserts a plain relative path resolves next to the config file.