### PR TITLE
config: fix TLSVersion.String() printing pointer address

### DIFF
--- a/config/http_config.go
+++ b/config/http_config.go
@@ -132,7 +132,7 @@ func (tv *TLSVersion) String() string {
 			return s
 		}
 	}
-	return fmt.Sprintf("%d", tv)
+	return fmt.Sprintf("%d", *tv)
 }
 
 // BasicAuth contains basic HTTP authentication credentials.

--- a/config/tls_config_test.go
+++ b/config/tls_config_test.go
@@ -137,6 +137,13 @@ func TestTLSVersionStringer(t *testing.T) {
 	require.Equalf(t, "TLS13", s.String(), "tls.VersionTLS13 string should be TLS13, got %s", s.String())
 }
 
+func TestTLSVersionStringerUnknown(t *testing.T) {
+	// An unknown TLS version (not present in TLSVersions) must fall back to its
+	// numeric value, not to the pointer address.
+	s := TLSVersion(0x9999) // 39321
+	require.Equal(t, "39321", s.String())
+}
+
 func TestTLSVersionMarshalYAML(t *testing.T) {
 	tests := []struct {
 		input    TLSVersion


### PR DESCRIPTION
## What

`TLSVersion.String()` falls back to `fmt.Sprintf("%d", tv)` for a version not present in the `TLSVersions` map — but `tv` is the `*TLSVersion` pointer, so it prints the pointer's memory address as a decimal integer instead of the numeric TLS version.

```go
func (tv *TLSVersion) String() string {
	if tv == nil || *tv == 0 {
		return ""
	}
	for s, v := range TLSVersions {
		if *tv == v {
			return s
		}
	}
	return fmt.Sprintf("%d", tv) // <- prints &tv address, not *tv
}
```

The sibling methods `MarshalYAML` and `MarshalJSON` already dereference correctly; `String()` was the lone outlier, and the existing test only covered the known-value path so it was never caught (`go vet` doesn't flag it either).

## Fix

Dereference the pointer: `tv` → `*tv`.

## Test

Added `TestTLSVersionStringerUnknown`. Before the fix it printed a pointer address (e.g. `"75679541043424"`); after, it correctly returns `"39321"`. `go test ./config/` is green.