### PR TITLE
route: add support for the QUERY HTTP method

### DIFF
--- a/route/route.go
+++ b/route/route.go
@@ -20,6 +20,11 @@ import (
 	"github.com/julienschmidt/httprouter"
 )
 
+// MethodQuery is the QUERY HTTP method. It is a safe, idempotent method that
+// carries a request body, see https://datatracker.ietf.org/doc/rfc10008/.
+// It is not yet part of net/http, so it is defined here.
+const MethodQuery = "QUERY"
+
 type param string
 
 // Param returns param p for the context, or the empty string when
@@ -112,6 +117,11 @@ func (r *Router) Post(path string, h http.HandlerFunc) {
 // Head registers a new HEAD route.
 func (r *Router) Head(path string, h http.HandlerFunc) {
 	r.rtr.HEAD(r.prefix+path, r.handle(path, h))
+}
+
+// Query registers a new QUERY route.
+func (r *Router) Query(path string, h http.HandlerFunc) {
+	r.rtr.Handle(MethodQuery, r.prefix+path, r.handle(path, h))
 }
 
 // Redirect takes an absolute path and sends an internal HTTP redirect for it,

--- a/route/route_test.go
+++ b/route/route_test.go
@@ -14,8 +14,10 @@
 package route
 
 import (
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -88,6 +90,30 @@ func TestContextWithoutValue(t *testing.T) {
 	r, err := http.NewRequest(http.MethodGet, "http://localhost:9090/test", nil)
 	require.NoErrorf(t, err, "Error building test request: %s", err)
 	router.ServeHTTP(nil, r)
+}
+
+func TestQuery(t *testing.T) {
+	router := New()
+	const body = "query=up"
+	called := false
+	router.Query("/test/:foo/", func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		want := "bar"
+		got := Param(r.Context(), "foo")
+		require.Equalf(t, want, got, "Unexpected context value: want %q, got %q", want, got)
+
+		gotBody, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.Equal(t, body, string(gotBody))
+		w.WriteHeader(http.StatusOK)
+	})
+
+	w := httptest.NewRecorder()
+	r, err := http.NewRequest(MethodQuery, "http://localhost:9090/test/bar/", strings.NewReader(body))
+	require.NoErrorf(t, err, "Error building test request: %s", err)
+	router.ServeHTTP(w, r)
+	require.Truef(t, called, "QUERY handler was not called")
+	require.Equal(t, http.StatusOK, w.Code)
 }
 
 func TestInstrumentation(t *testing.T) {


### PR DESCRIPTION
QUERY is a safe, idempotent method that carries a request body (RFC 10008). It is not yet part of net/http, so register it using a locally defined MethodQuery constant.