### PR TITLE
version: fix Slog godoc example to compile

### DIFF
--- a/version/example_test.go
+++ b/version/example_test.go
@@ -1,0 +1,26 @@
+// Copyright 2024 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version_test
+
+import (
+	"github.com/prometheus/common/promslog"
+	"github.com/prometheus/common/version"
+)
+
+// ExampleSlog mirrors the documented usage of version.Slog and keeps it
+// compiling, so the example in the godoc cannot drift from the real API.
+func ExampleSlog() {
+	logger := promslog.New(&promslog.Config{})
+	logger.Info("Starting Prometheus Server", version.Slog()...)
+}

--- a/version/info.go
+++ b/version/info.go
@@ -82,7 +82,7 @@ func BuildContext() string {
 // Slog returns a slice of strings for use with structured logging.
 //
 // Example:
-// logger := promslog.New(promslog.Config{})
+// logger := promslog.New(&promslog.Config{})
 // logger.Info("Starting Prometheus Server", version.Slog()...)
 func Slog() []any {
 	return []any{


### PR DESCRIPTION
The `Example` in the godoc for `version.Slog()` passes `promslog.Config{}` by value:

```go
logger := promslog.New(promslog.Config{})
logger.Info("Starting Prometheus Server", version.Slog()...)
```

but `promslog.New` takes a pointer:

```go
func New(config *Config) *slog.Logger
```

so the documented snippet does not compile. Building it verbatim fails with:

```
cannot use promslog.Config{} (value of struct type promslog.Config)
  as *promslog.Config value in argument to promslog.New
```

This changes it to `&promslog.Config{}`, matching the real call sites (`promslog/slog.go`, `promslog/slog_test.go`).

I also added a compiled `ExampleSlog` so the documented usage stays in sync with the API. It imports `promslog` only from the test file, so `version` gains no new runtime dependency. `gofmt`, `go vet ./version/...`, and `go test ./...` pass.