### PR TITLE
fix: use slog.DiscardHandler in promslog.NopLogger

### DIFF
--- a/promslog/slog.go
+++ b/promslog/slog.go
@@ -282,8 +282,8 @@ func New(config *Config) *slog.Logger {
 	return slog.New(slog.NewTextHandler(config.Writer, logHandlerOpts))
 }
 
-// NewNopLogger is a convenience function to return an slog.Logger that writes
-// to io.Discard.
+// NewNopLogger is a convenience function to return an slog.Logger that
+// discards all log records.
 func NewNopLogger() *slog.Logger {
-	return New(&Config{Writer: io.Discard})
+	return slog.New(slog.DiscardHandler)
 }

--- a/promslog/slog_test.go
+++ b/promslog/slog_test.go
@@ -254,3 +254,35 @@ func TestReservedKeys(t *testing.T) {
 		})
 	}
 }
+
+type expensiveValuer struct {
+	called *bool
+}
+
+func (v expensiveValuer) LogValue() slog.Value {
+	*v.called = true
+	return slog.StringValue("expensive")
+}
+
+func TestNewNopLogger(t *testing.T) {
+	logger := NewNopLogger()
+
+	for _, lvl := range []slog.Level{slog.LevelDebug, slog.LevelInfo, slog.LevelWarn, slog.LevelError} {
+		require.Falsef(t, logger.Enabled(context.Background(), lvl), "nop logger must be disabled for level %s", lvl)
+	}
+
+	// Arguments must never be evaluated, so that using a nop logger in a hot
+	// path stays free.
+	called := false
+	logger.Info("test", "expensive", expensiveValuer{called: &called})
+	require.False(t, called, "nop logger must not evaluate log arguments")
+}
+
+func BenchmarkNopLogger(b *testing.B) {
+	logger := NewNopLogger()
+	value := struct{ Field string }{Field: "value"}
+
+	for b.Loop() {
+		logger.Info("test", "key", value)
+	}
+}

--- a/promslog/slog_test.go
+++ b/promslog/slog_test.go
@@ -275,7 +275,7 @@ func TestNewNopLogger(t *testing.T) {
 	// path stays free.
 	called := false
 	logger.Info("test", "expensive", expensiveValuer{called: &called})
-	require.False(t, called, "nop logger must not evaluate log arguments")
+	require.Falsef(t, called, "nop logger must not evaluate log arguments")
 }
 
 func BenchmarkNopLogger(b *testing.B) {


### PR DESCRIPTION
Investigating huge latencies in pushgateway after upgrade from 1.10 to 1.11 I found out that the cause is the `promslog.NopLogger` (lets put aside that pushgateway logging might be too excessive)

It turned out that  `NewNopLogger()` returns `New(&Config{Writer: io.Discard})` — a regular `slog.TextHandler` at info level.
Its `Enabled()` returns true, so slog builds the record, the handler formats every attribute, and only then drops the bytes at `io.Discard`. For larger attributes this leads to meaningless serialization just to be thrown away.

- `checkWriteRequest` → `processWriteRequest` runs on every push.
- It logs `logger.Info(..., "new", mf, "old", existingMF)` — both `*dto.MetricFamily` with all their metrics.
- With a nop logger both get fully formatted on every push and thrown away.

### Fix:
Use the [slog.DiscardHandler](https://pkg.go.dev/log/slog#Handler) added in Go 1.24 which is really no-op.

##### :warning: What would change
- `slog.DiscardHandler` needs Go 1.24; this module is on 1.25.0.
  - Might be an issue if someone is using the common lib in older Go?
- `LogValuer` implementations with side effects will no longer be called.
- Code wrapping `NewNopLogger()` and expecting `Enabled()` to be true will stop seeing those calls.

##### Benchmark

Benchmark details — `go test ./promslog/ -run XXX -bench BenchmarkNopLogger -benchmem`, go1.26.5 linux/amd64, AMD Ryzen AI 7 445 (12 threads). `Old` is the current implementation, the other one is the patch.

```go
func BenchmarkNopLoggerOld(b *testing.B) {
	logger := New(&Config{Writer: io.Discard}) // current NewNopLogger()
	value := struct{ Field string }{Field: "value"}
	for b.Loop() {
		logger.Info("test", "key", value)
	}
}

func BenchmarkNopLogger(b *testing.B) {
	logger := NewNopLogger() // slog.New(slog.DiscardHandler)
	value := struct{ Field string }{Field: "value"}
	for b.Loop() {
		logger.Info("test", "key", value)
	}
}
```

```
goos: linux
goarch: amd64
pkg: github.com/prometheus/common/promslog
cpu: AMD Ryzen AI 7 445 w/ Radeon 840M
BenchmarkNopLoggerOld-12      352051      2890 ns/op     440 B/op    11 allocs/op
BenchmarkNopLogger-12       22288611      48.5 ns/op      16 B/op     1 allocs/op
```

