### PR TITLE
model: sort label names without boxing them into sort.Interface

### DIFF
--- a/model/signature.go
+++ b/model/signature.go
@@ -14,7 +14,7 @@
 package model
 
 import (
-	"sort"
+	"slices"
 )
 
 // SeparatorByte is a byte that cannot occur in valid UTF-8 sequences and is
@@ -37,7 +37,7 @@ func LabelsToSignature(labels map[string]string) uint64 {
 	for labelName := range labels {
 		labelNames = append(labelNames, labelName)
 	}
-	sort.Strings(labelNames)
+	slices.Sort(labelNames)
 
 	sum := hashNew()
 	for _, labelName := range labelNames {
@@ -60,7 +60,7 @@ func labelSetToFingerprint(ls LabelSet) Fingerprint {
 	for labelName := range ls {
 		labelNames = append(labelNames, labelName)
 	}
-	sort.Sort(labelNames)
+	slices.Sort(labelNames)
 
 	sum := hashNew()
 	for _, labelName := range labelNames {
@@ -100,7 +100,7 @@ func SignatureForLabels(m Metric, labels ...LabelName) uint64 {
 		return emptyLabelSignature
 	}
 
-	sort.Sort(LabelNames(labels))
+	slices.Sort(labels)
 
 	sum := hashNew()
 	for _, label := range labels {
@@ -129,7 +129,7 @@ func SignatureWithoutLabels(m Metric, labels map[LabelName]struct{}) uint64 {
 	if len(labelNames) == 0 {
 		return emptyLabelSignature
 	}
-	sort.Sort(labelNames)
+	slices.Sort(labelNames)
 
 	sum := hashNew()
 	for _, labelName := range labelNames {


### PR DESCRIPTION
SignatureForLabels becomes allocation-free, which matters because it is the only exported way to hash a subset of a label set. Alertmanager hit this in its inhibitor: it calls the equivalent once per inhibition rule per alert on GET `/api/v2/alerts`.

```
    benchstat over 8 runs (n=8, p=0.000 throughout):
    
      benchmark                     sec/op              B/op        allocs/op
      SignatureForLabels/1     60.71n -> 17.68n      24 -> 0       1 -> 0
      SignatureForLabels/2     95.40n -> 40.34n      24 -> 0       1 -> 0
      SignatureForLabels/3     121.40n -> 70.86n     24 -> 0       1 -> 0
      SignatureWithoutLabels   214.2n -> 184.8n      72 -> 48      2 -> 1
```
Benchmark here:
```go
func BenchmarkSignatureForLabels(b *testing.B) {
	m := Metric{
		"first-label":  "first-label-value",
		"second-label": "second-label-value",
		"third-label":  "third-label-value",
	}

	for _, n := range []int{1, 2, 3} {
		labels := make([]LabelName, 0, n)
		for ln := range m {
			labels = append(labels, ln)
			if len(labels) == n {
				break
			}
		}
		slices.Sort(labels)

		b.Run(strconv.Itoa(n)+"-labels", func(b *testing.B) {
			b.ReportAllocs()
			for b.Loop() {
				SignatureForLabels(m, labels...)
			}
		})
	}
}

func BenchmarkSignatureWithoutLabels(b *testing.B) {
	m := Metric{
		"first-label":  "first-label-value",
		"second-label": "second-label-value",
		"third-label":  "third-label-value",
	}
	exclude := map[LabelName]struct{}{"first-label": {}}

	b.ReportAllocs()
	for b.Loop() {
		SignatureWithoutLabels(m, exclude)
	}
}
```