### PR TITLE
fix: support exemplars with empty label sets in OpenMetrics 2.0

### DIFF
--- a/expfmt/openmetrics_2_0_create.go
+++ b/expfmt/openmetrics_2_0_create.go
@@ -260,7 +260,7 @@ func writeOpenMetrics20Sample(w enhancedWriter, name string, metric *dto.Metric,
 		}
 	}
 
-	if exemplar != nil && len(exemplar.Label) > 0 && exemplar.Timestamp != nil {
+	if exemplar != nil && exemplar.Timestamp != nil {
 		n, err = writeExemplar20(w, exemplar)
 		written += n
 		if err != nil {
@@ -279,7 +279,7 @@ func writeOpenMetrics20Sample(w enhancedWriter, name string, metric *dto.Metric,
 // writeExemplar20 writes the provided exemplar in OpenMetrics 2.0 format to w.
 // In OpenMetrics 2.0, exemplars without a timestamp are dropped.
 func writeExemplar20(w enhancedWriter, e *dto.Exemplar) (int, error) {
-	if e == nil || len(e.Label) == 0 || e.Timestamp == nil {
+	if e == nil || e.Timestamp == nil {
 		return 0, nil
 	}
 	if err := validateExemplar20(e); err != nil {
@@ -291,7 +291,11 @@ func writeExemplar20(w enhancedWriter, e *dto.Exemplar) (int, error) {
 	if err != nil {
 		return written, err
 	}
-	n, err = writeOpenMetricsNameAndLabelPairs(w, "", e.Label, "", 0)
+	if len(e.Label) == 0 {
+		n, err = w.WriteString("{}")
+	} else {
+		n, err = writeOpenMetricsNameAndLabelPairs(w, "", e.Label, "", 0)
+	}
 	written += n
 	if err != nil {
 		return written, err

--- a/expfmt/openmetrics_2_0_create_test.go
+++ b/expfmt/openmetrics_2_0_create_test.go
@@ -164,6 +164,27 @@ http_requests_total 1027 1234567891 st@1234567890 # {trace_id="1234"} 1 12345678
 `,
 		},
 		{
+			name: "CounterWithExemplarWithoutLabels",
+			in: &dto.MetricFamily{
+				Name: proto.String("http_requests_total"),
+				Type: dto.MetricType_COUNTER.Enum(),
+				Metric: []*dto.Metric{
+					{
+						Counter: &dto.Counter{
+							Value: proto.Float64(1027),
+							Exemplar: &dto.Exemplar{
+								Value:     proto.Float64(1),
+								Timestamp: &timestamppb.Timestamp{Seconds: 1234567890, Nanos: 500000000},
+							},
+						},
+					},
+				},
+			},
+			out: `# TYPE http_requests_total counter
+http_requests_total 1027 # {} 1 1234567890.5
+`,
+		},
+		{
 			name: "CounterWithExemplarWithoutTimestamp",
 			in: &dto.MetricFamily{
 				Name: proto.String("http_requests_total"),


### PR DESCRIPTION
Part of https://github.com/prometheus/common/issues/893

Split out of https://github.com/prometheus/common/pull/964

OpenMetrics 2.0 specification represents exemplars with an empty label set ({}). Previously, exemplars without labels were dropped.  From the [spec](https://prometheus.io/docs/specs/om/open_metrics_spec_2_0/#exemplars-1):

> "Exemplars without Labels MUST represent an empty LabelSet as {}."