### PR TITLE
expfmt: precompute parsed goautoneg.Accept for well-known Format constants

### DIFF
--- a/expfmt/encode.go
+++ b/expfmt/encode.go
@@ -27,6 +27,24 @@ import (
 	"github.com/prometheus/common/model"
 )
 
+var formatToAccept = map[Format]goautoneg.Accept{}
+
+func init() {
+	for _, f := range []Format{
+		FmtText,
+		FmtProtoDelim,
+		FmtProtoText,
+		FmtProtoCompact,
+		FmtOpenMetrics_1_0_0,
+		fmtOpenMetrics_2_0_0,
+		FmtOpenMetrics_0_0_1,
+	} {
+		if parsed := goautoneg.ParseAccept(string(f)); len(parsed) > 0 {
+			formatToAccept[f] = parsed[0]
+		}
+	}
+}
+
 // Encoder types encode metric families into an underlying wire protocol.
 type Encoder interface {
 	Encode(*dto.MetricFamily) error
@@ -81,7 +99,7 @@ func NegotiateIncludingOpenMetrics(h http.Header) Format {
 // format if present in the accepted list, or the first accepted format (or FmtText
 // if accepted is empty).
 func NegotiateAccept(h http.Header, accepted ...Format) Format {
-	escapingScheme := Format(fmt.Sprintf("; escaping=%s", Format(model.NameEscapingScheme.String())))
+	escapingScheme := Format("; escaping=" + model.NameEscapingScheme.String())
 	for _, ac := range goautoneg.ParseAccept(h.Get(hdrAccept)) {
 		if escapeParam := ac.Params[model.EscapingKey]; escapeParam != "" {
 			switch Format(escapeParam) {
@@ -111,11 +129,14 @@ func NegotiateAccept(h http.Header, accepted ...Format) Format {
 
 // matchFormat checks if a parsed accept clause matches a given Format.
 func matchFormat(ac goautoneg.Accept, f Format) bool {
-	parsed := goautoneg.ParseAccept(string(f))
-	if len(parsed) == 0 {
-		return false
+	target, ok := formatToAccept[f]
+	if !ok {
+		parsed := goautoneg.ParseAccept(string(f))
+		if len(parsed) == 0 {
+			return false
+		}
+		target = parsed[0]
 	}
-	target := parsed[0]
 
 	if ac.Type != "*" && ac.Type != target.Type {
 		return false

--- a/expfmt/encode_test.go
+++ b/expfmt/encode_test.go
@@ -547,3 +547,34 @@ func TestDottedEncode(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkNegotiate(b *testing.B) {
+	h := http.Header{}
+	h.Set(hdrAccept, "application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited;q=0.7,text/plain;version=0.0.4;q=0.3,application/json;q=0.1,*/*;q=0.01")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_ = Negotiate(h)
+	}
+}
+
+func BenchmarkNegotiateIncludingOpenMetrics(b *testing.B) {
+	h := http.Header{}
+	h.Set(hdrAccept, "application/openmetrics-text;version=1.0.0;q=0.8,application/openmetrics-text;version=0.0.1;q=0.5,text/plain;version=0.0.4;q=0.3,*/*;q=0.1")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_ = NegotiateIncludingOpenMetrics(h)
+	}
+}
+
+func BenchmarkNegotiateAccept(b *testing.B) {
+	h := http.Header{}
+	h.Set(hdrAccept, "application/openmetrics-text;version=1.0.0;q=0.8,text/plain;version=0.0.4;q=0.3,*/*;q=0.1")
+	accepted := []Format{FmtOpenMetrics_1_0_0, FmtOpenMetrics_0_0_1, FmtProtoDelim, FmtProtoText, FmtProtoCompact, FmtText}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_ = NegotiateAccept(h, accepted...)
+	}
+}


### PR DESCRIPTION
Fixes a small performance regression introduced by https://github.com/prometheus/common/pull/894.

Repeatedly parsing static Format constants with goautoneg.ParseAccept in matchFormat on every call causes heap allocations during negotiation.

Precompute the parsed goautoneg.Accept structs for standard Format constants at package initialization time, falling back to goautoneg.ParseAccept for custom formats. Also add benchmarks with b.ReportAllocs() to track negotiation performance.

```
goos: linux
goarch: amd64
pkg: github.com/prometheus/common/expfmt
cpu: AMD EPYC 7B12
                                 │ /tmp/before.txt │           /tmp/after.txt            │
                                 │     sec/op      │   sec/op     vs base                │
Negotiate-24                         3.074µ ±   6%   2.240µ ± 2%  -27.10% (p=0.000 n=10)
NegotiateIncludingOpenMetrics-24     3.180µ ±   3%   2.314µ ± 2%  -27.22% (p=0.000 n=10)
NegotiateAccept-24                   3.138µ ± 153%   1.768µ ± 4%  -43.67% (p=0.000 n=10)
geomean                              3.130µ          2.093µ       -33.14%

                                 │ /tmp/before.txt │            /tmp/after.txt            │
                                 │      B/op       │     B/op      vs base                │
Negotiate-24                          1.524Ki ± 0%   1.086Ki ± 0%  -28.76% (p=0.000 n=10)
NegotiateIncludingOpenMetrics-24      1.759Ki ± 0%   1.320Ki ± 0%  -24.93% (p=0.000 n=10)
NegotiateAccept-24                     1417.0 ± 0%     968.0 ± 0%  -31.69% (p=0.000 n=10)
geomean                               1.548Ki        1.107Ki       -28.51%

                                 │ /tmp/before.txt │           /tmp/after.txt           │
                                 │    allocs/op    │ allocs/op   vs base                │
Negotiate-24                           15.000 ± 0%   9.000 ± 0%  -40.00% (p=0.000 n=10)
NegotiateIncludingOpenMetrics-24        16.00 ± 0%   10.00 ± 0%  -37.50% (p=0.000 n=10)
NegotiateAccept-24                     14.000 ± 0%   8.000 ± 0%  -42.86% (p=0.000 n=10)
geomean                                 14.98        8.963       -40.16%
```