### PR TITLE
fix: drop invalid OpenMetrics 2.0 exemplars instead of failing exposition

### DIFF
--- a/expfmt/openmetrics_2_0_create.go
+++ b/expfmt/openmetrics_2_0_create.go
@@ -263,7 +263,7 @@ func writeOpenMetrics20Sample(w enhancedWriter, name string, metric *dto.Metric,
 		}
 	}
 
-	if exemplar != nil && exemplar.Timestamp != nil {
+	if exemplar != nil {
 		n, err = writeExemplar20(w, exemplar)
 		written += n
 		if err != nil {
@@ -280,13 +280,13 @@ func writeOpenMetrics20Sample(w enhancedWriter, name string, metric *dto.Metric,
 }
 
 // writeExemplar20 writes the provided exemplar in OpenMetrics 2.0 format to w.
-// In OpenMetrics 2.0, exemplars without a timestamp are dropped.
+// In OpenMetrics 2.0, invalid exemplars or exemplars without a timestamp are dropped.
 func writeExemplar20(w enhancedWriter, e *dto.Exemplar) (int, error) {
-	if e == nil || e.Timestamp == nil {
+	if e == nil {
 		return 0, nil
 	}
 	if err := validateExemplar20(e); err != nil {
-		return 0, err
+		return 0, nil
 	}
 	written := 0
 	n, err := w.WriteString(" # ")
@@ -315,10 +315,6 @@ func writeExemplar20(w enhancedWriter, e *dto.Exemplar) (int, error) {
 	}
 	err = w.WriteByte(' ')
 	written++
-	if err != nil {
-		return written, err
-	}
-	err = e.Timestamp.CheckValid()
 	if err != nil {
 		return written, err
 	}
@@ -387,6 +383,9 @@ func containsRawNewline(s string) bool {
 }
 
 func validateExemplar20(e *dto.Exemplar) error {
+	if e.Timestamp == nil {
+		return errors.New("exemplar timestamp is required")
+	}
 	if err := e.Timestamp.CheckValid(); err != nil {
 		return err
 	}

--- a/expfmt/openmetrics_2_0_create.go
+++ b/expfmt/openmetrics_2_0_create.go
@@ -285,6 +285,7 @@ func writeExemplar20(w enhancedWriter, e *dto.Exemplar) (int, error) {
 	if e == nil {
 		return 0, nil
 	}
+	// In OpenMetrics 2.0, invalid exemplars are dropped rather than failing the entire exposition.
 	if err := validateExemplar20(e); err != nil {
 		return 0, nil
 	}

--- a/expfmt/openmetrics_2_0_create_test.go
+++ b/expfmt/openmetrics_2_0_create_test.go
@@ -208,6 +208,102 @@ http_requests_total 1027.0
 `,
 		},
 		{
+			name: "CounterWithInvalidExemplarTimestamp",
+			in: &dto.MetricFamily{
+				Name: proto.String("http_requests_total"),
+				Type: dto.MetricType_COUNTER.Enum(),
+				Metric: []*dto.Metric{
+					{
+						Counter: &dto.Counter{
+							Value: proto.Float64(1027),
+							Exemplar: &dto.Exemplar{
+								Label: []*dto.LabelPair{
+									{Name: proto.String("trace_id"), Value: proto.String("1234")},
+								},
+								Value: proto.Float64(1),
+								Timestamp: &timestamppb.Timestamp{
+									Nanos: -1,
+								},
+							},
+						},
+					},
+				},
+			},
+			out: `# TYPE http_requests_total counter
+http_requests_total 1027
+`,
+		},
+		{
+			name: "CounterWithInvalidExemplarLabel",
+			in: &dto.MetricFamily{
+				Name: proto.String("http_requests_total"),
+				Type: dto.MetricType_COUNTER.Enum(),
+				Metric: []*dto.Metric{
+					{
+						Counter: &dto.Counter{
+							Value: proto.Float64(1027),
+							Exemplar: &dto.Exemplar{
+								Label: []*dto.LabelPair{
+									{Name: proto.String(""), Value: proto.String("1234")},
+								},
+								Value:     proto.Float64(1),
+								Timestamp: &timestamppb.Timestamp{Seconds: 1234567890},
+							},
+						},
+					},
+				},
+			},
+			out: `# TYPE http_requests_total counter
+http_requests_total 1027
+`,
+		},
+		{
+			name: "CounterWithNewlineInExemplarLabelName",
+			in: &dto.MetricFamily{
+				Name: proto.String("http_requests_total"),
+				Type: dto.MetricType_COUNTER.Enum(),
+				Metric: []*dto.Metric{
+					{
+						Counter: &dto.Counter{
+							Value: proto.Float64(1027),
+							Exemplar: &dto.Exemplar{
+								Label: []*dto.LabelPair{
+									{Name: proto.String("trace\nid"), Value: proto.String("1234")},
+								},
+								Value:     proto.Float64(1),
+								Timestamp: &timestamppb.Timestamp{Seconds: 1234567890},
+							},
+						},
+					},
+				},
+			},
+			out: `# TYPE http_requests_total counter
+http_requests_total 1027
+`,
+		},
+		{
+			name: "CounterWithNilExemplarLabelPair",
+			in: &dto.MetricFamily{
+				Name: proto.String("http_requests_total"),
+				Type: dto.MetricType_COUNTER.Enum(),
+				Metric: []*dto.Metric{
+					{
+						Counter: &dto.Counter{
+							Value: proto.Float64(1027),
+							Exemplar: &dto.Exemplar{
+								Label:     []*dto.LabelPair{nil},
+								Value:     proto.Float64(1),
+								Timestamp: &timestamppb.Timestamp{Seconds: 1234567890},
+							},
+						},
+					},
+				},
+			},
+			out: `# TYPE http_requests_total counter
+http_requests_total 1027
+`,
+		},
+		{
 			name: "CounterWithNaNExemplar",
 			in: &dto.MetricFamily{
 				Name: proto.String("http_requests_total"),
@@ -555,30 +651,6 @@ func TestCreateOpenMetrics20_Errors(t *testing.T) {
 				},
 			},
 			expectedErr: "invalid created timestamp in metric test_counter_total",
-		},
-		{
-			name: "ExemplarInvalidTimestamp",
-			in: &dto.MetricFamily{
-				Name: proto.String("test_counter_total"),
-				Type: dto.MetricType_COUNTER.Enum(),
-				Metric: []*dto.Metric{
-					{
-						Counter: &dto.Counter{
-							Value: proto.Float64(1.0),
-							Exemplar: &dto.Exemplar{
-								Label: []*dto.LabelPair{
-									{Name: proto.String("trace_id"), Value: proto.String("1234")},
-								},
-								Value: proto.Float64(1.0),
-								Timestamp: &timestamppb.Timestamp{
-									Nanos: -1,
-								},
-							},
-						},
-					},
-				},
-			},
-			expectedErr: "has out-of-range nanos",
 		},
 	}
 

--- a/expfmt/openmetrics_2_0_create_test.go
+++ b/expfmt/openmetrics_2_0_create_test.go
@@ -230,7 +230,7 @@ http_requests_total 1027.0
 				},
 			},
 			out: `# TYPE http_requests_total counter
-http_requests_total 1027
+http_requests_total 1027.0
 `,
 		},
 		{
@@ -254,7 +254,7 @@ http_requests_total 1027
 				},
 			},
 			out: `# TYPE http_requests_total counter
-http_requests_total 1027
+http_requests_total 1027.0
 `,
 		},
 		{
@@ -278,7 +278,7 @@ http_requests_total 1027
 				},
 			},
 			out: `# TYPE http_requests_total counter
-http_requests_total 1027
+http_requests_total 1027.0
 `,
 		},
 		{
@@ -300,7 +300,7 @@ http_requests_total 1027
 				},
 			},
 			out: `# TYPE http_requests_total counter
-http_requests_total 1027
+http_requests_total 1027.0
 `,
 		},
 		{


### PR DESCRIPTION
Small follow-up to https://github.com/prometheus/common/pull/894.

Per the OpenMetrics 2.0 specification failure modes, failures specific to exemplars should not cause the entire exposition to fail. Invalid exemplars (e.g. invalid timestamps, malformed labels) are now dropped so that the rest of the metric exposition succeeds.

> "This specification advocates for transactional processing: any encoding, decoding, or validation errors must reject the whole MetricSet ingestion. A failed scrape is better than an inaccurate scrape or a partial metric view that breaks transactionality (e.g., scraping a portion of a StateSet MetricGroup, or scraping only one Counter out of two that are aggregated in a single alert expression).

> There's one exception to this rule: failures specific to exemplars should not cause the entire exposition to fail. If an exemplar is malformed or invalid, it should be dropped or ignored, allowing the valid metric data to be ingested."

This also consolidates exemplar timestamp validation in `validateExemplar20`.