### PR TITLE
chore: update golangci-lint to v2.13 for go1.27 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,6 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    env:
-      # Override Go 1.18 security deprecations.
-      GODEBUG: "x509sha1=1,tls10default=1"
     strategy:
       matrix:
         go:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,8 +13,7 @@ linters:
     - misspell
     - modernize
     - nilnesserr
-    # TODO(bwplotka): Enable once https://github.com/golangci/golangci-lint/issues/3228 is fixed.
-    # - nolintlint
+    - nolintlint
     - perfsprint
     - predeclared
     - revive
@@ -44,9 +43,6 @@ linters:
       - linters:
           - gocritic
         text: "appendAssign"
-      - linters:
-          - errcheck
-        path: _test.go
     warn-unused: true
   settings:
     depguard:
@@ -177,7 +173,8 @@ formatters:
         - default
         - prefix(github.com/prometheus/common)
     gofumpt:
-      extra-rules: true
+      extra:
+        group-params: true
     goimports:
       local-prefixes:
         - github.com/prometheus/common

--- a/Makefile.common
+++ b/Makefile.common
@@ -61,7 +61,7 @@ PROMU_URL     := https://github.com/prometheus/promu/releases/download/v$(PROMU_
 SKIP_GOLANGCI_LINT :=
 GOLANGCI_LINT :=
 GOLANGCI_LINT_OPTS ?=
-GOLANGCI_LINT_VERSION ?= v2.12.2
+GOLANGCI_LINT_VERSION ?= v2.13.1
 GOLANGCI_FMT_OPTS ?=
 # golangci-lint only supports linux, darwin and windows platforms on i386/amd64/arm64.
 # windows isn't included here because of the path separator being different.

--- a/config/http_config.go
+++ b/config/http_config.go
@@ -71,10 +71,10 @@ type closeIdler interface {
 type TLSVersion uint16
 
 var TLSVersions = map[string]TLSVersion{
-	"TLS13": (TLSVersion)(tls.VersionTLS13),
-	"TLS12": (TLSVersion)(tls.VersionTLS12),
-	"TLS11": (TLSVersion)(tls.VersionTLS11),
-	"TLS10": (TLSVersion)(tls.VersionTLS10),
+	"TLS13": TLSVersion(tls.VersionTLS13),
+	"TLS12": TLSVersion(tls.VersionTLS12),
+	"TLS11": TLSVersion(tls.VersionTLS11),
+	"TLS10": TLSVersion(tls.VersionTLS10),
 }
 
 func (tv *TLSVersion) UnmarshalYAML(unmarshal func(any) error) error {
@@ -639,11 +639,13 @@ func NewRoundTripperFromConfigWithContext(ctx context.Context, cfg HTTPClientCon
 		dialContext = conntrack.NewDialContextFunc(
 			conntrack.DialWithDialContextFunc((func(context.Context, string, string) (net.Conn, error))(opts.dialContextFunc)),
 			conntrack.DialWithTracing(),
-			conntrack.DialWithName(name))
+			conntrack.DialWithName(name),
+		)
 	} else {
 		dialContext = conntrack.NewDialContextFunc(
 			conntrack.DialWithTracing(),
-			conntrack.DialWithName(name))
+			conntrack.DialWithName(name),
+		)
 	}
 
 	newRT := func(tlsConfig *tls.Config) (http.RoundTripper, error) {

--- a/config/tls_config_test.go
+++ b/config/tls_config_test.go
@@ -133,7 +133,7 @@ func TestInvalidTLSConfig(t *testing.T) {
 }
 
 func TestTLSVersionStringer(t *testing.T) {
-	s := (TLSVersion)(tls.VersionTLS13)
+	s := TLSVersion(tls.VersionTLS13)
 	require.Equalf(t, "TLS13", s.String(), "tls.VersionTLS13 string should be TLS13, got %s", s.String())
 }
 

--- a/route/route_test.go
+++ b/route/route_test.go
@@ -159,17 +159,20 @@ func TestInstrumentations(t *testing.T) {
 					func(handlerName string, handler http.HandlerFunc) http.HandlerFunc {
 						got = append(got, "1"+handlerName)
 						return handler
-					}).
+					},
+				).
 				WithInstrumentation(
 					func(handlerName string, handler http.HandlerFunc) http.HandlerFunc {
 						got = append(got, "2"+handlerName)
 						return handler
-					}).
+					},
+				).
 				WithInstrumentation(
 					func(handlerName string, handler http.HandlerFunc) http.HandlerFunc {
 						got = append(got, "3"+handlerName)
 						return handler
-					}),
+					},
+				),
 			want: []string{"1/foo", "2/foo", "3/foo"},
 		},
 	}


### PR DESCRIPTION
- fix linting
- ci: remove obsolete GODEBUG settings

  Remove the x509sha1 and tls10default compatibility settings from the
  test environment. Neither is supported by the minimum tested Go version,
  and x509sha1 causes binaries built with recent Go versions to fail at
  startup.

- chore: update golangci-lint to v2.13 for go1.27 compatibility
