### PR TITLE
fix(config): deep copy the header in cloneRequest

### DIFF
--- a/config/headers_test.go
+++ b/config/headers_test.go
@@ -69,6 +69,35 @@ func TestHeadersRoundTripperSameHost(t *testing.T) {
 	}
 }
 
+func TestHeadersRoundTripperReusedRequest(t *testing.T) {
+	// The round tripper must not mutate the request it is given: reusing the
+	// same request must not accumulate another copy of every header.
+	var received []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received = r.Header.Values("X-Custom-Header")
+		fmt.Fprint(w, "ok")
+	}))
+	t.Cleanup(server.Close)
+
+	headers := &Headers{
+		Headers: map[string]Header{
+			"X-Custom-Header": {Values: []string{"testvalue"}},
+		},
+	}
+	rt := NewHeadersRoundTripper(headers, http.DefaultTransport)
+
+	req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+	require.NoError(t, err)
+
+	for i := range 3 {
+		resp, err := rt.RoundTrip(req)
+		require.NoError(t, err)
+		resp.Body.Close()
+		require.Equalf(t, []string{"testvalue"}, received, "header duplicated on request %d", i+1)
+		require.Empty(t, req.Header.Values("X-Custom-Header"), "the caller's request was modified")
+	}
+}
+
 func TestHeadersRoundTripperCrossHostRedirect(t *testing.T) {
 	// Cookie must be set on the initial request but stripped on cross-host redirects.
 	cookieOnRedirect := ""

--- a/config/headers_test.go
+++ b/config/headers_test.go
@@ -94,7 +94,7 @@ func TestHeadersRoundTripperReusedRequest(t *testing.T) {
 		require.NoError(t, err)
 		resp.Body.Close()
 		require.Equalf(t, []string{"testvalue"}, received, "header duplicated on request %d", i+1)
-		require.Empty(t, req.Header.Values("X-Custom-Header"), "the caller's request was modified")
+		require.Emptyf(t, req.Header.Values("X-Custom-Header"), "the caller's request was modified")
 	}
 }
 

--- a/config/http_config.go
+++ b/config/http_config.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"maps"
 	"net"
 	"net/http"
 	"net/url"
@@ -1240,8 +1239,13 @@ func cloneRequest(r *http.Request) *http.Request {
 	// Shallow copy of the struct.
 	r2 := new(http.Request)
 	*r2 = *r
-	// Deep copy of the Header.
-	maps.Copy(r.Header, r2.Header)
+	// Deep copy of the Header. The shallow copy above leaves r2.Header
+	// aliasing r.Header, so without this every round tripper that adds a
+	// header would mutate the caller's request.
+	r2.Header = r.Header.Clone()
+	if r2.Header == nil {
+		r2.Header = make(http.Header)
+	}
 	return r2
 }
 

--- a/config/http_config_test.go
+++ b/config/http_config_test.go
@@ -2749,3 +2749,27 @@ func TestLoadHTTPConfigFileResolvesPathsRelativeToConfigFile(t *testing.T) {
 	_, err = client.Get(ts.URL)
 	require.NoErrorf(t, err, "can't fetch URL: %v", err)
 }
+
+func TestCloneRequest(t *testing.T) {
+	t.Run("clone does not share the caller's header", func(t *testing.T) {
+		r, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+		require.NoError(t, err)
+		r.Header.Set("X-Original", "value")
+
+		r2 := cloneRequest(r)
+		r2.Header.Add("X-Added", "value")
+
+		require.Equal(t, "value", r2.Header.Get("X-Original"), "existing headers must be carried over")
+		require.Empty(t, r.Header.Values("X-Added"), "the original request must not be modified")
+	})
+
+	t.Run("clone of a request without a header is usable", func(t *testing.T) {
+		r, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+		require.NoError(t, err)
+		r.Header = nil
+
+		r2 := cloneRequest(r)
+		require.NotPanics(t, func() { r2.Header.Set("X-Added", "value") })
+		require.Nil(t, r.Header, "the original request must not be modified")
+	})
+}

--- a/config/http_config_test.go
+++ b/config/http_config_test.go
@@ -2759,8 +2759,8 @@ func TestCloneRequest(t *testing.T) {
 		r2 := cloneRequest(r)
 		r2.Header.Add("X-Added", "value")
 
-		require.Equal(t, "value", r2.Header.Get("X-Original"), "existing headers must be carried over")
-		require.Empty(t, r.Header.Values("X-Added"), "the original request must not be modified")
+		require.Equalf(t, "value", r2.Header.Get("X-Original"), "existing headers must be carried over")
+		require.Emptyf(t, r.Header.Values("X-Added"), "the original request must not be modified")
 	})
 
 	t.Run("clone of a request without a header is usable", func(t *testing.T) {
@@ -2770,6 +2770,6 @@ func TestCloneRequest(t *testing.T) {
 
 		r2 := cloneRequest(r)
 		require.NotPanics(t, func() { r2.Header.Set("X-Added", "value") })
-		require.Nil(t, r.Header, "the original request must not be modified")
+		require.Nilf(t, r.Header, "the original request must not be modified")
 	})
 }


### PR DESCRIPTION
Fixes #981.

`cloneRequest` intends a deep copy of the header but does not make one:

```go
r2 := new(http.Request)
*r2 = *r
// Deep copy of the Header.
maps.Copy(r.Header, r2.Header)
```

After `*r2 = *r`, `r2.Header` is already the same map as `r.Header`, so `maps.Copy` copies it onto itself and the clone shares the caller's header map.

Every round tripper here clones and then modifies, so each one mutates the request it was given. `headersRoundTripper` uses `Header.Add`, so a reused request gains another copy of every configured header on each round trip, without bound. [grafana/alloy#7016](https://github.com/grafana/alloy/issues/7016) reports ~1000 identical `X-Api-Key` lines in a single request, with the target returning 431 and profiling stopping.

Introduced in 56870db, which replaced the manual copy loop with `maps.Copy`. The arguments are also the wrong way round, but swapping them is not enough — the clone needs its own map.

`Header.Clone()` returns nil for a nil header, while the previous code always produced a usable map, so the nil case is kept: `userAgentRoundTripper` and others call `Header.Set` straight after cloning, which panics with `assignment to entry in nil map` on a request built without one. That path is broken on main today as well.

## Tests

Two tests, both failing on main and passing here:

- `TestCloneRequest` — the clone must not share the caller's map, and a request without a header must still be usable afterwards.
- `TestHeadersRoundTripperReusedRequest` — reusing a request must not accumulate headers, and must not modify the caller's request.

`go build ./...`, `go test ./...` and `go test -race ./config/` are green on darwin/arm64, go1.26.5.